### PR TITLE
feat(state): :sparkles: Permite N estados

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ add_commonlibsse_plugin(ElementalReactionsFramework
     src/hud/TrueHUDMenuWatcher.cpp
     src/elemental_reactions/erf_element.cpp
     src/elemental_reactions/erf_reaction.cpp
+    src/elemental_reactions/erf_state.cpp
 )
 
 target_include_directories(ElementalReactionsFramework PRIVATE ${truehud_SOURCE_DIR}/src)
@@ -54,6 +55,7 @@ target_precompile_headers(ElementalReactionsFramework PRIVATE
   src/hud/TrueHUDMenuWatcher.h
   src/elemental_reactions/erf_element.h
   src/elemental_reactions/erf_reaction.h
+  src/elemental_reactions/erf_state.h
 )
 
 if(DEFINED OUTPUT_FOLDER)

--- a/src/elemental_reactions/ElementalGauges.cpp
+++ b/src/elemental_reactions/ElementalGauges.cpp
@@ -113,17 +113,20 @@ namespace Gauges {
         if (!a || delta <= 0) return delta;
 
         const ERF_ElementDesc* ed = ElementRegistry::get().get(h);
-        if (!ed) return delta;
+        if (!ed || ed->stateMultipliers.empty()) return delta;
 
         double f = 1.0;
-        for (const auto& [flag, mult] : ed->stateMultipliers) {
-            if (ElementalStates::Get(a, flag)) {
+
+        for (const auto& [sh, mult] : ed->stateMultipliers) {
+            if (sh == 0) continue;
+            if (ElementalStates::IsActive(a, sh)) {
                 f *= mult;
             }
         }
 
         const double out = std::round(static_cast<double>(delta) * f);
-        return static_cast<int>(out < 0.0 ? 0.0 : out);
+        if (out <= 0.0) return 0;
+        return static_cast<int>(out);
     }
 }
 

--- a/src/elemental_reactions/ElementalStates.h
+++ b/src/elemental_reactions/ElementalStates.h
@@ -1,15 +1,22 @@
 #pragma once
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include "RE/Skyrim.h"
-#include "SKSE/SKSE.h"
+#include "erf_state.h"
 
 namespace ElementalStates {
-    enum class Flag : std::uint8_t { Wet = 0, Rubber = 1, Fur = 2 };
-
     void RegisterStore();
 
-    void Set(RE::Actor* a, Flag f, bool value);
-    bool Get(RE::Actor* a, Flag f);
+    bool SetActive(RE::Actor* a, ERF_StateHandle sh, bool value);
+    bool IsActive(RE::Actor* a, ERF_StateHandle sh);
+
+    void Activate(RE::Actor* a, ERF_StateHandle sh);
+    void Deactivate(RE::Actor* a, ERF_StateHandle sh);
+
     void Clear(RE::Actor* a);
     void ClearAll();
+
+    std::vector<ERF_StateHandle> GetActive(RE::Actor* a);
 }

--- a/src/elemental_reactions/erf_element.h
+++ b/src/elemental_reactions/erf_element.h
@@ -6,8 +6,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include "ElementalStates.h"
 #include "RE/Skyrim.h"
+#include "erf_state.h"
 
 using ERF_ElementHandle = std::uint16_t;
 
@@ -15,7 +15,15 @@ struct ERF_ElementDesc {
     std::string name;
     std::uint32_t colorRGB;
     RE::BGSKeyword* keyword;
-    std::unordered_map<ElementalStates::Flag, double> stateMultipliers;
+    std::unordered_map<ERF_StateHandle, double> stateMultipliers;
+    void setMultiplierForState(ERF_StateHandle sh, double mult) {
+        if (sh != 0) stateMultipliers[sh] = mult;
+    }
+    double getMultiplierForState(ERF_StateHandle sh, double fallback = 1.0) const {
+        if (sh == 0) return fallback;
+        if (auto it = stateMultipliers.find(sh); it != stateMultipliers.end()) return it->second;
+        return fallback;
+    }
 };
 
 class ElementRegistry {

--- a/src/elemental_reactions/erf_state.cpp
+++ b/src/elemental_reactions/erf_state.cpp
@@ -1,0 +1,42 @@
+#include "erf_state.h"
+
+StateRegistry& StateRegistry::get() {
+    static StateRegistry R;
+    if (R._states.empty()) {
+        R._states.resize(1);
+    }
+    return R;
+}
+
+ERF_StateHandle StateRegistry::registerState(const ERF_StateDesc& d) {
+    auto& R = get();
+    if (R._states.empty()) R._states.resize(1);
+    R._states.push_back(d);
+    return static_cast<ERF_StateHandle>(R._states.size() - 1);
+}
+
+const ERF_StateDesc* StateRegistry::get(ERF_StateHandle h) const {
+    if (h == 0) return nullptr;
+    if (static_cast<std::size_t>(h) >= _states.size()) return nullptr;
+    return &_states[h];
+}
+
+std::optional<ERF_StateHandle> StateRegistry::findByName(std::string_view name) const {
+    for (ERF_StateHandle h = 1; h < _states.size(); ++h) {
+        const auto& s = _states[h];
+        if (s.name == name) return h;
+    }
+    return std::nullopt;
+}
+
+std::optional<ERF_StateHandle> StateRegistry::findByKeyword(const RE::BGSKeyword* kw) const {
+    if (!kw) return std::nullopt;
+    const auto want = kw->GetFormID();
+    for (ERF_StateHandle h = 1; h < _states.size(); ++h) {
+        const auto& s = _states[h];
+        if (s.keyword && s.keyword->GetFormID() == want) return h;
+    }
+    return std::nullopt;
+}
+
+std::size_t StateRegistry::size() const noexcept { return (_states.size() > 0) ? (_states.size() - 1) : 0; }

--- a/src/elemental_reactions/erf_state.h
+++ b/src/elemental_reactions/erf_state.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "RE/Skyrim.h"
+
+using ERF_StateHandle = std::uint16_t;
+
+struct ERF_StateDesc {
+    std::string name;
+    RE::BGSKeyword* keyword = nullptr;
+};
+
+class StateRegistry {
+public:
+    static StateRegistry& get();
+
+    ERF_StateHandle registerState(const ERF_StateDesc& d);
+
+    const ERF_StateDesc* get(ERF_StateHandle h) const;
+    std::optional<ERF_StateHandle> findByName(std::string_view name) const;
+    std::optional<ERF_StateHandle> findByKeyword(const RE::BGSKeyword* kw) const;
+
+    std::size_t size() const noexcept;
+
+private:
+    StateRegistry() = default;
+    std::vector<ERF_StateDesc> _states;
+};


### PR DESCRIPTION
Refatorei para permitir cadastrar N estados elementais e que cada elemento possa um multiplicador X para cada estado elemental.

## Summary by Sourcery

Implement a dynamic elemental state system: introduce StateRegistry for arbitrary states, refactor storage and serialization, update APIs and element handling to use state handles, and register default states and multipliers at startup.

New Features:
- Register arbitrary number of elemental states via a dynamic StateRegistry
- Assign custom multiplier values per elemental state for each element

Enhancements:
- Refactor state storage from fixed bitflags to a per-actor map of ERF_StateHandle sets
- Overhaul serialization logic to read/write dynamic state lists with versioning
- Replace old ElementalStates API with Activate/Deactivate/IsActive/GetActive methods
- Update elemental descriptor and gauge calculation to use state handles instead of enum flags
- Register default states and link state multipliers to vanilla elements during plugin initialization

Build:
- Include erf_state.cpp and erf_state.h in the CMake build