### PR TITLE
feat(reactions): :sparkles: Criado a logica para registrar as pre rea…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_commonlibsse_plugin(ElementalReactionsFramework
     src/elemental_reactions/erf_element.cpp
     src/elemental_reactions/erf_reaction.cpp
     src/elemental_reactions/erf_state.cpp
+    src/elemental_reactions/erf_preeffect.cpp
 )
 
 target_include_directories(ElementalReactionsFramework PRIVATE ${truehud_SOURCE_DIR}/src)
@@ -56,6 +57,7 @@ target_precompile_headers(ElementalReactionsFramework PRIVATE
   src/elemental_reactions/erf_element.h
   src/elemental_reactions/erf_reaction.h
   src/elemental_reactions/erf_state.h
+  src/elemental_reactions/erf_preeffect.h
 )
 
 if(DEFINED OUTPUT_FOLDER)

--- a/src/elemental_reactions/erf_preeffect.cpp
+++ b/src/elemental_reactions/erf_preeffect.cpp
@@ -1,0 +1,30 @@
+#include "erf_preeffect.h"
+
+PreEffectRegistry& PreEffectRegistry::get() {
+    static PreEffectRegistry R;
+    if (R._effects.empty()) R._effects.resize(1);
+    return R;
+}
+
+ERF_PreEffectHandle PreEffectRegistry::registerPreEffect(const ERF_PreEffectDesc& d) {
+    auto& R = get();
+    if (R._effects.empty()) R._effects.resize(1);
+    ERF_PreEffectDesc copy = d;
+    R._effects.push_back(std::move(copy));
+    const auto h = static_cast<ERF_PreEffectHandle>(R._effects.size() - 1);
+    const auto eh = d.element;
+    const std::size_t need = static_cast<std::size_t>(eh) + 1;
+    if (R._byElem.size() < need) R._byElem.resize(need);
+    R._byElem[eh].push_back(h);
+    return h;
+}
+
+const ERF_PreEffectDesc* PreEffectRegistry::get(ERF_PreEffectHandle h) const {
+    if (h == 0 || h >= _effects.size()) return nullptr;
+    return &_effects[h];
+}
+
+std::vector<ERF_PreEffectHandle> PreEffectRegistry::listByElement(ERF_ElementHandle h) const {
+    if (h == 0 || h >= _byElem.size()) return {};
+    return _byElem[h];
+}

--- a/src/elemental_reactions/erf_preeffect.h
+++ b/src/elemental_reactions/erf_preeffect.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "RE/Skyrim.h"
+#include "erf_element.h"
+
+using ERF_PreEffectHandle = std::uint16_t;
+
+struct ERF_PreEffectDesc {
+    std::string name;
+
+    ERF_ElementHandle element = 0;
+
+    std::uint8_t minGauge = 1;
+
+    float durationSeconds = 2.0f;
+    bool durationIsRealTime = true;
+
+    float cooldownSeconds = 0.5f;
+    bool cooldownIsRealTime = true;
+
+    float baseIntensity = 0.0f;
+    float scalePerPoint = 0.0f;
+    float minIntensity = 0.0f;
+    float maxIntensity = 1.0f;
+
+    using Callback = void (*)(RE::Actor* actor, ERF_ElementHandle element, std::uint8_t gauge, float intensity,
+                              void* user);
+    Callback cb = nullptr;
+    void* user = nullptr;
+};
+
+class PreEffectRegistry {
+public:
+    static PreEffectRegistry& get();
+
+    ERF_PreEffectHandle registerPreEffect(const ERF_PreEffectDesc& d);
+    const ERF_PreEffectDesc* get(ERF_PreEffectHandle h) const;
+
+    std::vector<ERF_PreEffectHandle> listByElement(ERF_ElementHandle h) const;
+
+private:
+    PreEffectRegistry() = default;
+    std::vector<ERF_PreEffectDesc> _effects;
+    std::vector<std::vector<ERF_PreEffectHandle>> _byElem;
+};


### PR DESCRIPTION
…ções

criado a estrutura preeffect que permitir ativar efeitos baseado na quantidade de gauge atual de um determinado elemento

## Summary by Sourcery

Introduce a pre-effect system that allows registering and applying continuous element-based effects based on current gauge values, integrating the logic into the gauge update loop and providing an example shock-slow preEffect.

New Features:
- Add preEffect descriptor and registry for element-based continuous effects
- Trigger and manage preEffects dynamically based on gauge thresholds in ElementalGauges
- Register an example shock slow preEffect that scales intensity with the Shock gauge

Enhancements:
- Integrate preEffect evaluation into the gauge update workflow
- Support SKSE task interface for deferred callback execution when applying preEffects

Build:
- Include new erf_preeffect.cpp/h files in the CMake build configuration