### PR TITLE
feat(Menu): :sparkles: Opção de desativar mod e salvar as configurações

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,8 +4,7 @@
       "name": "x64",
       "includePath": [
         "${workspaceFolder}/src",
-        "${workspaceFolder}/build/release/vcpkg_installed/x64-windows-static-md/include",
-        "${workspaceFolder}/build/release/_deps/truehud-src/src"
+        "${workspaceFolder}/build/release/vcpkg_installed/x64-windows-static-md/include"
       ],
       "defines": ["UNICODE", "_DEBUG"],
       "windowsSdkVersion": "10.0.19041.0",

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,6 +1,57 @@
 #include "Config.h"
 
+#include <SKSE/SKSE.h>
+#include <SimpleIni.h>
+
+#include <cctype>
+#include <string>
+
 namespace ERF {
+    static bool loadBool(CSimpleIniA& ini, const char* sec, const char* key, bool defVal) {
+        const char* val = ini.GetValue(sec, key, nullptr);
+        if (!val) return defVal;
+        std::string s = val;
+        for (auto& c : s) c = (char)std::tolower((unsigned char)c);
+        if (s == "1" || s == "true" || s == "on") return true;
+        if (s == "0" || s == "false" || s == "off") return false;
+        return defVal;
+    }
+
+    std::filesystem::path Config::IniPath() {
+        auto dirOpt = SKSE::log::log_directory();
+        if (!dirOpt) {
+            return std::filesystem::path("ElementalReactionsFramework.ini");
+        }
+        auto p = *dirOpt / "ElementalReactionsFramework.ini";
+        return p;
+    }
+
+    void Config::Load() {
+        CSimpleIniA ini;
+        ini.SetUnicode();
+        const auto path = IniPath();
+        SI_Error rc = ini.LoadFile(path.string().c_str());
+        if (rc < 0) {
+            spdlog::info("[ERF] Config::Load: usando defaults (sem ini em {})", path.string());
+            return;
+        }
+        bool en = loadBool(ini, "General", "Enabled", true);
+        enabled.store(en, std::memory_order_relaxed);
+        spdlog::info("[ERF] Config::Load: Enabled={}", en);
+    }
+
+    void Config::Save() const {
+        CSimpleIniA ini;
+        ini.SetUnicode();
+        const auto path = IniPath();
+        ini.LoadFile(path.string().c_str());
+        ini.SetBoolValue("General", "Enabled", enabled.load(std::memory_order_relaxed));
+        std::error_code ec;
+        std::filesystem::create_directories(path.parent_path(), ec);
+        ini.SaveFile(path.string().c_str());
+        spdlog::info("[ERF] Config::Save: wrote {}", path.string());
+    }
+
     Config& GetConfig() {
         static Config g_cfg{};
         return g_cfg;

--- a/src/Config.h
+++ b/src/Config.h
@@ -1,8 +1,17 @@
 #pragma once
 #include <atomic>
+#include <filesystem>
 
 namespace ERF {
-    struct Config {};
+    struct Config {
+        std::atomic<bool> enabled{true};
+
+        void Load();
+        void Save() const;
+
+    private:
+        static std::filesystem::path IniPath();
+    };
 
     Config& GetConfig();
 }

--- a/src/elemental_reactions/ElementalGaugesHook.cpp
+++ b/src/elemental_reactions/ElementalGaugesHook.cpp
@@ -12,6 +12,7 @@
 #include <type_traits>
 #include <unordered_map>
 
+#include "../Config.h"
 #include "../common/Helpers.h"
 #include "../hud/HUDTick.h"
 #include "ElementalGauges.h"
@@ -62,6 +63,8 @@ namespace {
             }
         }
     };
+
+    inline bool IsDisabled() noexcept { return !ERF::GetConfig().enabled.load(std::memory_order_relaxed); }
 }
 
 namespace GaugesHook {
@@ -198,6 +201,8 @@ namespace GaugesHook {
         static void thunk(T* self, RE::MagicTarget* mt) {
             _orig(self, mt);
 
+            if (IsDisabled()) return;
+
             const RE::EffectSetting* mgef = self ? self->GetBaseObject() : nullptr;
 
             RE::Actor* actor = AsActor(self ? self->target : nullptr);
@@ -244,6 +249,10 @@ namespace GaugesHook {
         static inline Fn* _orig{};
 
         static void thunk(T* self, float dt) {
+            if (IsDisabled()) {
+                _orig(self, dt);
+                return;
+            }
             const auto* mgef = self->GetBaseObject();
             if (mgef && IsGaugeAccCarrier(mgef)) {
                 _orig(self, dt);

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -3,6 +3,7 @@
 #include <thread>
 #include <utility>
 
+#include "Config.h"
 #include "ElementalReactionsAPI.h"
 #include "ModAPI.h"
 #include "PCH.h"
@@ -75,6 +76,7 @@ namespace {
                         }
                     });
 
+                ERF::GetConfig().Load();
                 ERF_UI::Register();
                 break;
             }

--- a/src/ui/ERF_UI.cpp
+++ b/src/ui/ERF_UI.cpp
@@ -3,7 +3,15 @@
 void __stdcall ERF_UI::DrawGeneral() {
     ImGui::TextUnformatted("Elemental Reactions Framework");
     ImGui::Separator();
-    ImGui::TextUnformatted("Hello from ERF! (menu de teste)");
+
+    bool enabled = ERF::GetConfig().enabled.load(std::memory_order_relaxed);
+    if (ImGui::Checkbox("Enable framework", &enabled)) {
+        ERF::GetConfig().enabled.store(enabled, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+
+    ImGui::SameLine();
+    ImGui::TextDisabled(enabled ? "(enabled)" : "(disabled)");
 }
 
 void ERF_UI::Register() {

--- a/src/ui/ERF_UI.h
+++ b/src/ui/ERF_UI.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Config.h"
 #include "SKSEMenuFramework.h"
 
 namespace ERF_UI {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-    "dependencies": [
-        "commonlibsse-ng"
-    ]
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "elemental-reactions-framework",
+  "version-string": "0.0.1",
+  "dependencies": ["commonlibsse-ng", "simpleini"]
 }


### PR DESCRIPTION
Adicionei no config uma opção para ativar e desativar o mod. Além disso implementei a funcionalidade de salvar as configurações ao serem alteradas e de carregar as configurações salvas ao abrir o jogo. Foi adicionado novas dependencias no vcpkg e removido a entrada do truehud do c_pp_properties

## Summary by Sourcery

Add a configuration option to enable or disable the framework, persist the setting in an INI file, integrate it into both the UI and hook logic, and update project dependencies accordingly

New Features:
- Expose an 'Enable framework' checkbox in the menu to toggle the mod
- Persist the mod's enabled/disabled state across sessions via an INI file

Enhancements:
- Implement Config::Load, Config::Save, and IniPath using SimpleIni and std::filesystem for configuration management
- Integrate the enabled flag into hook logic to short-circuit mod functionality when disabled

Build:
- Update vcpkg.json with new dependencies and remove the TrueHUD entry from c_cpp_properties.json