### PR TITLE
feat(Menu): :sparkles: Opção para habilitar e desabilitar a hud de gauge

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -32,12 +32,12 @@ namespace ERF {
         const auto path = IniPath();
         SI_Error rc = ini.LoadFile(path.string().c_str());
         if (rc < 0) {
-            spdlog::info("[ERF] Config::Load: usando defaults (sem ini em {})", path.string());
             return;
         }
         bool en = loadBool(ini, "General", "Enabled", true);
         enabled.store(en, std::memory_order_relaxed);
-        spdlog::info("[ERF] Config::Load: Enabled={}", en);
+        bool hud = loadBool(ini, "HUD", "Enabled", true);
+        hudEnabled.store(hud, std::memory_order_relaxed);
     }
 
     void Config::Save() const {
@@ -46,10 +46,10 @@ namespace ERF {
         const auto path = IniPath();
         ini.LoadFile(path.string().c_str());
         ini.SetBoolValue("General", "Enabled", enabled.load(std::memory_order_relaxed));
+        ini.SetBoolValue("HUD", "Enabled", hudEnabled.load(std::memory_order_relaxed));
         std::error_code ec;
         std::filesystem::create_directories(path.parent_path(), ec);
         ini.SaveFile(path.string().c_str());
-        spdlog::info("[ERF] Config::Save: wrote {}", path.string());
     }
 
     Config& GetConfig() {

--- a/src/Config.h
+++ b/src/Config.h
@@ -5,6 +5,7 @@
 namespace ERF {
     struct Config {
         std::atomic<bool> enabled{true};
+        std::atomic<bool> hudEnabled{true};
 
         void Load();
         void Save() const;

--- a/src/elemental_reactions/ElementalGaugesHook.cpp
+++ b/src/elemental_reactions/ElementalGaugesHook.cpp
@@ -366,6 +366,9 @@ namespace HookThread {
 std::atomic_bool ElementalGaugesHook::ALLOW_HUD_TICK{false};
 
 void ElementalGaugesHook::StartHUDTick() {
+    if (!ERF::GetConfig().hudEnabled.load(std::memory_order_relaxed)) {
+        return;
+    }
     if (!ALLOW_HUD_TICK.load(std::memory_order_acquire)) return;
     const auto now = duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
     HookThread::g_lastHookMs.store(now, std::memory_order_relaxed);

--- a/src/ui/ERF_UI.cpp
+++ b/src/ui/ERF_UI.cpp
@@ -12,6 +12,14 @@ void __stdcall ERF_UI::DrawGeneral() {
 
     ImGui::SameLine();
     ImGui::TextDisabled(enabled ? "(enabled)" : "(disabled)");
+
+    ImGui::Separator();
+
+    bool hud = ERF::GetConfig().hudEnabled.load(std::memory_order_relaxed);
+    if (ImGui::Checkbox("Show HUD", &hud)) {
+        ERF::GetConfig().hudEnabled.store(hud, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
 }
 
 void ERF_UI::Register() {


### PR DESCRIPTION
## Summary by Sourcery

Add option to toggle the gauge HUD in the UI and persist the setting

New Features:
- Add 'Show HUD' checkbox in the UI to enable or disable the gauge HUD

Enhancements:
- Introduce hudEnabled flag in Config and persist it under the 'HUD' section of the ini file
- Respect hudEnabled flag by skipping HUD updates when disabled