### PR TITLE
feat(menu): :sparkles: Novas configurações de menu mixed/single

### DIFF
--- a/include/TrueHUDAPI.h
+++ b/include/TrueHUDAPI.h
@@ -1,403 +1,405 @@
 #pragma once
-#include <functional>
-#include <queue>
 #include <stdint.h>
 
+#include <functional>
+#include <queue>
+
 /*
-* For modders: Copy this file into your own project if you wish to use this API
-*/
-namespace TRUEHUD_API
-{
-	constexpr const auto TrueHUDPluginName = "TrueHUD";
+ * For modders: Copy this file into your own project if you wish to use this API
+ */
+namespace TRUEHUD_API {
+    constexpr const auto TrueHUDPluginName = "TrueHUD";
 
-	// Available True HUD interface versions
-	enum class InterfaceVersion : uint8_t
-	{
-		V1,
-		V2,
-		V3,
-		V4
-	};
+    // Available True HUD interface versions
+    enum class InterfaceVersion : uint8_t { V1, V2, V3, V4 };
 
-	// Error types that may be returned by the True HUD
-	enum class APIResult : uint8_t
-	{
-		// Your API call was successful
-		OK,
+    // Error types that may be returned by the True HUD
+    enum class APIResult : uint8_t {
+        // Your API call was successful
+        OK,
 
-		// You tried to release a resource that was not allocated to you
-		// Do not attempt to manipulate the requested resource if you receive this response
-		NotOwner,
+        // You tried to release a resource that was not allocated to you
+        // Do not attempt to manipulate the requested resource if you receive this response
+        NotOwner,
 
-		// True HUD currently must keep control of this resource for proper functionality
-		// Do not attempt to manipulate the requested resource if you receive this response
-		MustKeep,
+        // True HUD currently must keep control of this resource for proper functionality
+        // Do not attempt to manipulate the requested resource if you receive this response
+        MustKeep,
 
-		// You have already been given control of this resource
-		AlreadyGiven,
+        // You have already been given control of this resource
+        AlreadyGiven,
 
-		// Another mod has been given control of this resource at the present time
-		// Do not attempt to manipulate the requested resource if you receive this response
-		AlreadyTaken,
+        // Another mod has been given control of this resource at the present time
+        // Do not attempt to manipulate the requested resource if you receive this response
+        AlreadyTaken,
 
-		// The widget clip failed to load
-		WidgetFailedToLoad,
+        // The widget clip failed to load
+        WidgetFailedToLoad,
 
-		// You sent a command on a thread that could cause a data race were it to be processed
-		// Do not attempt to manipulate the requested resource if you receive this response
-		BadThread,
-	};
+        // You sent a command on a thread that could cause a data race were it to be processed
+        // Do not attempt to manipulate the requested resource if you receive this response
+        BadThread,
+    };
 
-	// Removal modes of the widget when requesting an info bar to be removed
-	enum class WidgetRemovalMode : std::uint8_t
-	{
-		// The widget will be removed instantly
-		Immediate,
+    // Removal modes of the widget when requesting an info bar to be removed
+    enum class WidgetRemovalMode : std::uint8_t {
+        // The widget will be removed instantly
+        Immediate,
 
-		// A short fade to zero opacity will start instantly, after which the widget will be removed
-		Normal,
+        // A short fade to zero opacity will start instantly, after which the widget will be removed
+        Normal,
 
-		// The fade to zero opacity will start after a short delay (normally used on dead targets)
-		Delayed
-	};
+        // The fade to zero opacity will start after a short delay (normally used on dead targets)
+        Delayed
+    };
 
-	// Player widget bar types
-	enum class PlayerWidgetBarType : std::uint8_t
-	{
-		HealthBar,
-		MagickaBar,
-		StaminaBar,
-		SpecialBar
-	};
+    // Player widget bar types
+    enum class PlayerWidgetBarType : std::uint8_t { HealthBar, MagickaBar, StaminaBar, SpecialBar };
 
-	// Bar color types
-	enum class BarColorType : std::uint8_t
-	{
-		BarColor,
-		PhantomColor,
-		BackgroundColor,
-		PenaltyColor,
-		FlashColor
-	};
+    // Bar color types
+    enum class BarColorType : std::uint8_t { BarColor, PhantomColor, BackgroundColor, PenaltyColor, FlashColor };
 
-	using SpecialResourceCallback = std::function<float(RE::Actor* a_actor)>;
-	using APIResultCallback = std::function<void(APIResult)>;
+    using SpecialResourceCallback = std::function<float(RE::Actor* a_actor)>;
+    using APIResultCallback = std::function<void(APIResult)>;
 
-	// Widget base class
-	class WidgetBase
-	{
-	public:
-		using WidgetTask = std::function<void()>;
-		using Lock = std::recursive_mutex;
-		using Locker = std::lock_guard<Lock>;
+    // Widget base class
+    class WidgetBase {
+    public:
+        using WidgetTask = std::function<void()>;
+        using Lock = std::recursive_mutex;
+        using Locker = std::lock_guard<Lock>;
 
-		enum WidgetState : std::uint8_t
-		{
-			kActive = 0,
-			kPendingHide = 1,
-			kHidden = 2,
-			kDelayedRemoval = 3,
-			kPendingRemoval = 4,
-			kRemoved = 5
-		};
+        enum WidgetState : std::uint8_t {
+            kActive = 0,
+            kPendingHide = 1,
+            kHidden = 2,
+            kDelayedRemoval = 3,
+            kPendingRemoval = 4,
+            kRemoved = 5
+        };
 
-		WidgetBase() = default;
-		virtual ~WidgetBase() = default;
+        WidgetBase() = default;
+        virtual ~WidgetBase() = default;
 
-		WidgetBase(RE::GPtr<RE::GFxMovieView> a_view) :
-			_view(a_view),
-			_widgetID(0)
-		{}
+        WidgetBase(RE::GPtr<RE::GFxMovieView> a_view) : _view(a_view), _widgetID(0) {}
 
-		WidgetBase(uint32_t a_widgetID) :
-			_widgetID(a_widgetID)
-		{}
+        WidgetBase(uint32_t a_widgetID) : _widgetID(a_widgetID) {}
 
-		WidgetBase(RE::GPtr<RE::GFxMovieView> a_view, uint32_t a_widgetID) :
-			_view(a_view),
-			_widgetID(a_widgetID)
-		{}
+        WidgetBase(RE::GPtr<RE::GFxMovieView> a_view, uint32_t a_widgetID) : _view(a_view), _widgetID(a_widgetID) {}
 
-		virtual void Update(float a_deltaTime) = 0;
-		virtual void Initialize() = 0;
-		virtual void Dispose() = 0;
-		virtual void SetWidgetState(WidgetState a_newWidgetState)
-		{
-			_widgetState = a_newWidgetState;
-		}
+        virtual void Update(float a_deltaTime) = 0;
+        virtual void Initialize() = 0;
+        virtual void Dispose() = 0;
+        virtual void SetWidgetState(WidgetState a_newWidgetState) { _widgetState = a_newWidgetState; }
 
-		void AddWidgetTask(WidgetTask a_task)
-		{
-			Locker locker(_lock);
-			_taskQueue.push(std::move(a_task));
-		}
+        void AddWidgetTask(WidgetTask a_task) {
+            Locker locker(_lock);
+            _taskQueue.push(std::move(a_task));
+        }
 
-		void ProcessDelegates()
-		{
-			while (!_taskQueue.empty()) {
-				auto& task = _taskQueue.front();
-				task();
-				_taskQueue.pop();
-			}
-		}
+        void ProcessDelegates() {
+            while (!_taskQueue.empty()) {
+                auto& task = _taskQueue.front();
+                task();
+                _taskQueue.pop();
+            }
+        }
 
-		RE::GPtr<RE::GFxMovieView> _view;
-		RE::GFxValue _object;
-		uint32_t _widgetID;
+        RE::GPtr<RE::GFxMovieView> _view;
+        RE::GFxValue _object;
+        uint32_t _widgetID;
 
-		mutable Lock _lock;
-		std::queue<WidgetTask> _taskQueue;
+        mutable Lock _lock;
+        std::queue<WidgetTask> _taskQueue;
 
-		WidgetState _widgetState = WidgetState::kHidden;
+        WidgetState _widgetState = WidgetState::kHidden;
 
-		float _depth = 0;
-	};
+        float _depth = 0;
+    };
 
-	// True HUD's modder interface
-	class IVTrueHUD1
-	{
-	public:
-		/// <summary>
-		/// Get the thread ID True HUD Movement is running in.
-		/// You may compare this with the result of GetCurrentThreadId() to help determine
-		/// if you are using the correct thread.
-		/// </summary>
-		/// <returns>TID</returns>
-		[[nodiscard]] virtual unsigned long GetTrueHUDThreadId() const noexcept = 0;
+    // True HUD's modder interface
+    class IVTrueHUD1 {
+    public:
+        /// <summary>
+        /// Get the thread ID True HUD Movement is running in.
+        /// You may compare this with the result of GetCurrentThreadId() to help determine
+        /// if you are using the correct thread.
+        /// </summary>
+        /// <returns>TID</returns>
+        [[nodiscard]] virtual unsigned long GetTrueHUDThreadId() const noexcept = 0;
 
-		/// <summary>
-		/// Request control of the current target (affects actor info bar mode)
-		/// If granted, you may manipulate the current target and soft target in whatever ways you wish for the duration of your control.
-		/// </summary>
-		/// <param name="a_myPluginHandle">Your assigned plugin handle</param>
-		/// <returns>OK, AlreadyGiven, AlreadyTaken</returns>
-		[[nodiscard]] virtual APIResult RequestTargetControl(SKSE::PluginHandle a_myPluginHandle) noexcept = 0;
+        /// <summary>
+        /// Request control of the current target (affects actor info bar mode)
+        /// If granted, you may manipulate the current target and soft target in whatever ways you wish for the duration
+        /// of your control.
+        /// </summary>
+        /// <param name="a_myPluginHandle">Your assigned plugin handle</param>
+        /// <returns>OK, AlreadyGiven, AlreadyTaken</returns>
+        [[nodiscard]] virtual APIResult RequestTargetControl(SKSE::PluginHandle a_myPluginHandle) noexcept = 0;
 
-		/// <summary>
-		/// Request control over the special resource bars.
-		/// If granted, you may provide the functions that will be used to get the special bars' fill percent.
-		/// </summary>
-		/// <param name="a_myPluginHandle">Your assigned plugin handle</param>
-		/// <returns>OK, AlreadyGiven, AlreadyTaken</returns>
-		[[nodiscard]] virtual APIResult RequestSpecialResourceBarsControl(SKSE::PluginHandle a_myPluginHandle) noexcept = 0;
+        /// <summary>
+        /// Request control over the special resource bars.
+        /// If granted, you may provide the functions that will be used to get the special bars' fill percent.
+        /// </summary>
+        /// <param name="a_myPluginHandle">Your assigned plugin handle</param>
+        /// <returns>OK, AlreadyGiven, AlreadyTaken</returns>
+        [[nodiscard]] virtual APIResult RequestSpecialResourceBarsControl(
+            SKSE::PluginHandle a_myPluginHandle) noexcept = 0;
 
-		/// <summary>
-		/// Tries to set the current target to the given actor handle. Will only do so if granted target control.
-		/// </summary>
-		/// <param name="a_myPluginHandle">Your assigned plugin handle</param>
-		/// <returns>OK, NotOwner</returns>
-		virtual APIResult SetTarget(SKSE::PluginHandle a_myPluginHandle, RE::ActorHandle a_actorHandle) noexcept = 0;
+        /// <summary>
+        /// Tries to set the current target to the given actor handle. Will only do so if granted target control.
+        /// </summary>
+        /// <param name="a_myPluginHandle">Your assigned plugin handle</param>
+        /// <returns>OK, NotOwner</returns>
+        virtual APIResult SetTarget(SKSE::PluginHandle a_myPluginHandle, RE::ActorHandle a_actorHandle) noexcept = 0;
 
-		/// <summary>
-		/// Tries to set the current soft target to the given actor handle. Will only do so if granted target control.
-		/// </summary>
-		/// <param name="a_myPluginHandle">Your assigned plugin handle</param>
-		/// <returns>OK, NotOwner</returns>
-		virtual APIResult SetSoftTarget(SKSE::PluginHandle a_myPluginHandle, RE::ActorHandle a_actorHandle) noexcept = 0;
+        /// <summary>
+        /// Tries to set the current soft target to the given actor handle. Will only do so if granted target control.
+        /// </summary>
+        /// <param name="a_myPluginHandle">Your assigned plugin handle</param>
+        /// <returns>OK, NotOwner</returns>
+        virtual APIResult SetSoftTarget(SKSE::PluginHandle a_myPluginHandle,
+                                        RE::ActorHandle a_actorHandle) noexcept = 0;
 
-		/// <summary>
-		/// Tries to create an info bar widget for the given actor handle.
-		/// </summary>
-		/// <param name="a_actorHandle">Actor handle</param>
-		virtual void AddActorInfoBar(RE::ActorHandle a_actorHandle) noexcept = 0;
+        /// <summary>
+        /// Tries to create an info bar widget for the given actor handle.
+        /// </summary>
+        /// <param name="a_actorHandle">Actor handle</param>
+        virtual void AddActorInfoBar(RE::ActorHandle a_actorHandle) noexcept = 0;
 
-		/// <summary>
-		/// Tries to remove an info bar widget for the given actor handle.
-		/// </summary>
-		/// <param name="a_actorHandle">Actor handle</param>
-		/// <param name="a_removalMode">How quickly should the widget be removed</param>
-		virtual void RemoveActorInfoBar(RE::ActorHandle a_actorHandle, WidgetRemovalMode a_removalMode) noexcept = 0;
+        /// <summary>
+        /// Tries to remove an info bar widget for the given actor handle.
+        /// </summary>
+        /// <param name="a_actorHandle">Actor handle</param>
+        /// <param name="a_removalMode">How quickly should the widget be removed</param>
+        virtual void RemoveActorInfoBar(RE::ActorHandle a_actorHandle, WidgetRemovalMode a_removalMode) noexcept = 0;
 
-		/// <summary>
-		/// Adds an actor handle to the boss queue.
-		/// </summary>
-		/// <param name="a_actorHandle">Actor handle</param>
-		virtual void AddBoss(RE::ActorHandle a_actorHandle) noexcept = 0;
+        /// <summary>
+        /// Adds an actor handle to the boss queue.
+        /// </summary>
+        /// <param name="a_actorHandle">Actor handle</param>
+        virtual void AddBoss(RE::ActorHandle a_actorHandle) noexcept = 0;
 
-		/// <summary>
-		/// Tries to remove an actor handle from the boss queue / a boss bar widget, if exists.
-		/// </summary>
-		/// <param name="a_actorHandle">Actor handle</param>
-		/// <param name="a_removalMode">How quickly should the widget be removed</param>
-		virtual void RemoveBoss(RE::ActorHandle a_actorHandle, WidgetRemovalMode a_removalMode) noexcept = 0;
+        /// <summary>
+        /// Tries to remove an actor handle from the boss queue / a boss bar widget, if exists.
+        /// </summary>
+        /// <param name="a_actorHandle">Actor handle</param>
+        /// <param name="a_removalMode">How quickly should the widget be removed</param>
+        virtual void RemoveBoss(RE::ActorHandle a_actorHandle, WidgetRemovalMode a_removalMode) noexcept = 0;
 
-		/// <summary>
-		/// Tries to send a visual flash event related to the given actor value on a widget related to the given actor handle (similar to vanilla stamina bar flashing when trying to sprint while it's empty). Will only succeed if such a target exists and is supported by the widget.
-		/// </summary>
-		/// <param name="a_actorHandle">Actor handle</param>
-		/// <param name="a_actorValue">Actor value represented on the bar you want to flash</param>
-		/// <param name="a_bLong">Play longer flash animation</param>
-		virtual void FlashActorValue(RE::ActorHandle a_actorHandle, RE::ActorValue a_actorValue, bool a_bLong) noexcept = 0;
+        /// <summary>
+        /// Tries to send a visual flash event related to the given actor value on a widget related to the given actor
+        /// handle (similar to vanilla stamina bar flashing when trying to sprint while it's empty). Will only succeed
+        /// if such a target exists and is supported by the widget.
+        /// </summary>
+        /// <param name="a_actorHandle">Actor handle</param>
+        /// <param name="a_actorValue">Actor value represented on the bar you want to flash</param>
+        /// <param name="a_bLong">Play longer flash animation</param>
+        virtual void FlashActorValue(RE::ActorHandle a_actorHandle, RE::ActorValue a_actorValue,
+                                     bool a_bLong) noexcept = 0;
 
-		/// <summary>
-		/// Tries to send a visual flash event on a special bar related to the given actor handle. Will only do so if granted control.
-		/// </summary>
-		/// <param name="a_myPluginHandle">Your assigned plugin handle</param>
-		/// <param name="a_actorHandle">Actor handle</param>
-		/// <param name="a_bLong">Play longer flash animation</param>
-		/// <returns>OK, NotOwner</returns>
-		virtual APIResult FlashActorSpecialBar(SKSE::PluginHandle a_myPluginHandle, RE::ActorHandle a_actorHandle, bool a_bLong) noexcept = 0;
+        /// <summary>
+        /// Tries to send a visual flash event on a special bar related to the given actor handle. Will only do so if
+        /// granted control.
+        /// </summary>
+        /// <param name="a_myPluginHandle">Your assigned plugin handle</param>
+        /// <param name="a_actorHandle">Actor handle</param>
+        /// <param name="a_bLong">Play longer flash animation</param>
+        /// <returns>OK, NotOwner</returns>
+        virtual APIResult FlashActorSpecialBar(SKSE::PluginHandle a_myPluginHandle, RE::ActorHandle a_actorHandle,
+                                               bool a_bLong) noexcept = 0;
 
-		/// <summary>
-		/// Registers the special resource functions
-		/// </summary>
-		/// <param name="a_myPluginHandle">Your assigned plugin handle</param>
-		/// <param name="a_getCurrentSpecialResource">Function that will return current special resource value</param>
-		/// <param name="a_getMaxSpecialResource">Function that will return max special resource value</param>
-		/// <param name="a_bSpecialMode">Whether the max value is default and 0 is the flash threshold (true), or the other way around (false)</param>
-		/// <param name="a_bDisplaySpecialForPlayer">Whether the special bar should be displayed for the player as well</param>
-		/// <returns>OK, NotOwner</returns>
-		virtual APIResult RegisterSpecialResourceFunctions(SKSE::PluginHandle a_myPluginHandle, SpecialResourceCallback&& a_getCurrentSpecialResource, SpecialResourceCallback&& a_getMaxSpecialResource, bool a_bSpecialMode, bool a_bDisplaySpecialForPlayer = true) noexcept = 0;
+        /// <summary>
+        /// Registers the special resource functions
+        /// </summary>
+        /// <param name="a_myPluginHandle">Your assigned plugin handle</param>
+        /// <param name="a_getCurrentSpecialResource">Function that will return current special resource value</param>
+        /// <param name="a_getMaxSpecialResource">Function that will return max special resource value</param>
+        /// <param name="a_bSpecialMode">Whether the max value is default and 0 is the flash threshold (true), or the
+        /// other way around (false)</param> <param name="a_bDisplaySpecialForPlayer">Whether the special bar should be
+        /// displayed for the player as well</param> <returns>OK, NotOwner</returns>
+        virtual APIResult RegisterSpecialResourceFunctions(SKSE::PluginHandle a_myPluginHandle,
+                                                           SpecialResourceCallback&& a_getCurrentSpecialResource,
+                                                           SpecialResourceCallback&& a_getMaxSpecialResource,
+                                                           bool a_bSpecialMode,
+                                                           bool a_bDisplaySpecialForPlayer = true) noexcept = 0;
 
-		/// <summary>
-		/// Loads a custom widget swf. First step in registering a custom widget.
-		/// </summary>
-		/// <param name="a_myPluginHandle">Your assigned plugin handle</param>
-		/// <param name="a_filePath">File path to the .swf file, relative to the Data/Interface folder</param>
-		/// <param name="a_successCallback">Function that will be called back when done. Check the result before proceeding.</param>
-		virtual void LoadCustomWidgets(SKSE::PluginHandle a_myPluginHandle, std::string_view a_filePath, APIResultCallback&& a_successCallback) noexcept = 0;
+        /// <summary>
+        /// Loads a custom widget swf. First step in registering a custom widget.
+        /// </summary>
+        /// <param name="a_myPluginHandle">Your assigned plugin handle</param>
+        /// <param name="a_filePath">File path to the .swf file, relative to the Data/Interface folder</param>
+        /// <param name="a_successCallback">Function that will be called back when done. Check the result before
+        /// proceeding.</param>
+        virtual void LoadCustomWidgets(SKSE::PluginHandle a_myPluginHandle, std::string_view a_filePath,
+                                       APIResultCallback&& a_successCallback) noexcept = 0;
 
-		/// <summary>
-		/// Registers a new widget type. Second step in registering a custom widget.
-		/// </summary>
-		/// <param name="a_myPluginHandle">Your assigned plugin handle</param>
-		/// <param name="a_widgetType">A pluginwide unique ID of the widget type.</param>
-		virtual void RegisterNewWidgetType(SKSE::PluginHandle a_myPluginHandle, uint32_t a_widgetType) noexcept = 0;
+        /// <summary>
+        /// Registers a new widget type. Second step in registering a custom widget.
+        /// </summary>
+        /// <param name="a_myPluginHandle">Your assigned plugin handle</param>
+        /// <param name="a_widgetType">A pluginwide unique ID of the widget type.</param>
+        virtual void RegisterNewWidgetType(SKSE::PluginHandle a_myPluginHandle, uint32_t a_widgetType) noexcept = 0;
 
-		/// <summary>
-		/// Adds a custom widget. Will succeed only if prepared correctly by calling the previous two functions.
-		/// </summary>
-		/// <param name="a_myPluginHandle">Your assigned plugin handle</param>
-		/// <param name="a_widgetType">A pluginwide unique ID of the widget type.</param>
-		/// <param name="a_widgetID">An unique ID of the widget.</param>
-		/// <param name="a_symbolIdentifier">The ActionScript linkage name of the movieclip</param>
-		/// <param name="a_widget">The shared pointer to the widget (based on the WidgetBase class) created in your plugin</param>
-		virtual void AddWidget(SKSE::PluginHandle a_myPluginHandle, uint32_t a_widgetType, uint32_t a_widgetID, std::string_view a_symbolIdentifier, std::shared_ptr<WidgetBase> a_widget) noexcept = 0;
+        /// <summary>
+        /// Adds a custom widget. Will succeed only if prepared correctly by calling the previous two functions.
+        /// </summary>
+        /// <param name="a_myPluginHandle">Your assigned plugin handle</param>
+        /// <param name="a_widgetType">A pluginwide unique ID of the widget type.</param>
+        /// <param name="a_widgetID">An unique ID of the widget.</param>
+        /// <param name="a_symbolIdentifier">The ActionScript linkage name of the movieclip</param>
+        /// <param name="a_widget">The shared pointer to the widget (based on the WidgetBase class) created in your
+        /// plugin</param>
+        virtual void AddWidget(SKSE::PluginHandle a_myPluginHandle, uint32_t a_widgetType, uint32_t a_widgetID,
+                               std::string_view a_symbolIdentifier, std::shared_ptr<WidgetBase> a_widget) noexcept = 0;
 
-		/// <summary>
-		/// Removes a custom widget.
-		/// </summary>
-		/// <param name="a_myPluginHandle">Your assigned plugin handle</param>
-		/// <param name="a_widgetType">A pluginwide unique ID of the widget type.</param>
-		/// <param name="a_widgetID">An unique ID of the widget.</param>
-		/// <param name="a_removalMode">Indicates whether the widget should be removed instantly. Modes other than Immediate have to be handled inside the widget</param>
-		virtual void RemoveWidget(SKSE::PluginHandle a_myPluginHandle, uint32_t a_widgetType, uint32_t a_widgetID, WidgetRemovalMode a_removalMode) noexcept = 0;
+        /// <summary>
+        /// Removes a custom widget.
+        /// </summary>
+        /// <param name="a_myPluginHandle">Your assigned plugin handle</param>
+        /// <param name="a_widgetType">A pluginwide unique ID of the widget type.</param>
+        /// <param name="a_widgetID">An unique ID of the widget.</param>
+        /// <param name="a_removalMode">Indicates whether the widget should be removed instantly. Modes other than
+        /// Immediate have to be handled inside the widget</param>
+        virtual void RemoveWidget(SKSE::PluginHandle a_myPluginHandle, uint32_t a_widgetType, uint32_t a_widgetID,
+                                  WidgetRemovalMode a_removalMode) noexcept = 0;
 
-		/// <summary>
-		/// Returns the plugin handle of the plugin controlling the current target resource.
-		/// </summary>
-		/// <returns>Handle or kSKSE::PluginHandle_Invalid if no one currently owns the resource</returns>
-		virtual SKSE::PluginHandle GetTargetControlOwner() const noexcept = 0;
+        /// <summary>
+        /// Returns the plugin handle of the plugin controlling the current target resource.
+        /// </summary>
+        /// <returns>Handle or kSKSE::PluginHandle_Invalid if no one currently owns the resource</returns>
+        virtual SKSE::PluginHandle GetTargetControlOwner() const noexcept = 0;
 
-		/// <summary>
-		/// Returns the plugin handle of the plugin controlling player widget bar colors.
-		/// </summary>
-		/// <returns>Handle or kSKSE::PluginHandle_Invalid if no one currently owns the resource</returns>
-		virtual SKSE::PluginHandle GetPlayerWidgetBarColorsControlOwner() const noexcept = 0;
+        /// <summary>
+        /// Returns the plugin handle of the plugin controlling player widget bar colors.
+        /// </summary>
+        /// <returns>Handle or kSKSE::PluginHandle_Invalid if no one currently owns the resource</returns>
+        virtual SKSE::PluginHandle GetPlayerWidgetBarColorsControlOwner() const noexcept = 0;
 
-		/// <summary>
-		/// Returns the plugin handle of the plugin controlling special resource bars.
-		/// </summary>
-		/// <returns>Handle or kSKSE::PluginHandle_Invalid if no one currently owns the resource</returns>
-		virtual SKSE::PluginHandle GetSpecialResourceBarControlOwner() const noexcept = 0;
+        /// <summary>
+        /// Returns the plugin handle of the plugin controlling special resource bars.
+        /// </summary>
+        /// <returns>Handle or kSKSE::PluginHandle_Invalid if no one currently owns the resource</returns>
+        virtual SKSE::PluginHandle GetSpecialResourceBarControlOwner() const noexcept = 0;
 
-		/// <summary>
-		/// Release your control of the target resource.
-		/// </summary>
-		/// <param name="a_myPluginHandle">Your assigned plugin handle</param>
-		/// <returns>OK, NotOwner</returns>
-		virtual APIResult ReleaseTargetControl(SKSE::PluginHandle a_myPluginHandle) noexcept = 0;
+        /// <summary>
+        /// Release your control of the target resource.
+        /// </summary>
+        /// <param name="a_myPluginHandle">Your assigned plugin handle</param>
+        /// <returns>OK, NotOwner</returns>
+        virtual APIResult ReleaseTargetControl(SKSE::PluginHandle a_myPluginHandle) noexcept = 0;
 
-		/// <summary>
-		/// Release your control of the special resource bars.
-		/// </summary>
-		/// <param name="a_myPluginHandle">Your assigned plugin handle</param>
-		/// <returns>OK, NotOwner</returns>
-		virtual APIResult ReleaseSpecialResourceBarControl(SKSE::PluginHandle a_myPluginHandle) noexcept = 0;
-	};
+        /// <summary>
+        /// Release your control of the special resource bars.
+        /// </summary>
+        /// <param name="a_myPluginHandle">Your assigned plugin handle</param>
+        /// <returns>OK, NotOwner</returns>
+        virtual APIResult ReleaseSpecialResourceBarControl(SKSE::PluginHandle a_myPluginHandle) noexcept = 0;
+    };
 
-	class IVTrueHUD2 : public IVTrueHUD1
-	{
-	public:
-		/// <summary>
-		/// Overrides the bar color for the given actor handle and color type.
-		/// </summary>
-		/// <param name="a_actorHandle">Actor handle</param>
-		/// <param name="a_actorValue">Actor value represented on the bar you want to override</param>
-		/// <param name="a_colorType">Which color you want to override</param>
-		/// <param name="a_color">The color in hex</param>
-		virtual void OverrideBarColor(RE::ActorHandle a_actorHandle, RE::ActorValue a_actorValue, BarColorType a_colorType, uint32_t a_color) noexcept = 0;
+    class IVTrueHUD2 : public IVTrueHUD1 {
+    public:
+        /// <summary>
+        /// Overrides the bar color for the given actor handle and color type.
+        /// </summary>
+        /// <param name="a_actorHandle">Actor handle</param>
+        /// <param name="a_actorValue">Actor value represented on the bar you want to override</param>
+        /// <param name="a_colorType">Which color you want to override</param>
+        /// <param name="a_color">The color in hex</param>
+        virtual void OverrideBarColor(RE::ActorHandle a_actorHandle, RE::ActorValue a_actorValue,
+                                      BarColorType a_colorType, uint32_t a_color) noexcept = 0;
 
-		/// <summary>
-		/// Overrides the special bar color for the given actor handle and color type.
-		/// </summary>
-		/// <param name="a_actorHandle">Actor handle</param>
-		/// <param name="a_colorType">Which color you want to override</param>
-		/// <param name="a_color">The color in hex</param>
-		virtual void OverrideSpecialBarColor(RE::ActorHandle a_actorHandle, BarColorType a_colorType, uint32_t a_color) noexcept = 0;
+        /// <summary>
+        /// Overrides the special bar color for the given actor handle and color type.
+        /// </summary>
+        /// <param name="a_actorHandle">Actor handle</param>
+        /// <param name="a_colorType">Which color you want to override</param>
+        /// <param name="a_color">The color in hex</param>
+        virtual void OverrideSpecialBarColor(RE::ActorHandle a_actorHandle, BarColorType a_colorType,
+                                             uint32_t a_color) noexcept = 0;
 
-		/// <summary>
-		/// Reverts the bar color for the given actor handle and color type.
-		/// </summary>
-		/// <param name="a_actorHandle">Actor handle</param>
-		/// <param name="a_actorValue">Actor value represented on the bar you want to revert</param>
-		/// <param name="a_colorType">Which color you want to revert</param>
-		virtual void RevertBarColor(RE::ActorHandle a_actorHandle, RE::ActorValue a_actorValue, BarColorType a_colorType) noexcept = 0;
+        /// <summary>
+        /// Reverts the bar color for the given actor handle and color type.
+        /// </summary>
+        /// <param name="a_actorHandle">Actor handle</param>
+        /// <param name="a_actorValue">Actor value represented on the bar you want to revert</param>
+        /// <param name="a_colorType">Which color you want to revert</param>
+        virtual void RevertBarColor(RE::ActorHandle a_actorHandle, RE::ActorValue a_actorValue,
+                                    BarColorType a_colorType) noexcept = 0;
 
-		/// <summary>
-		/// Reverts the special bar color for the given actor handle and color type.
-		/// </summary>
-		/// <param name="a_actorHandle">Actor handle</param>
-		/// <param name="a_colorType">Which color you want to revert</param>
-		virtual void RevertSpecialBarColor(RE::ActorHandle a_actorHandle, BarColorType a_colorType) noexcept = 0;
-	};
+        /// <summary>
+        /// Reverts the special bar color for the given actor handle and color type.
+        /// </summary>
+        /// <param name="a_actorHandle">Actor handle</param>
+        /// <param name="a_colorType">Which color you want to revert</param>
+        virtual void RevertSpecialBarColor(RE::ActorHandle a_actorHandle, BarColorType a_colorType) noexcept = 0;
+    };
 
-	class IVTrueHUD3 : public IVTrueHUD2
-	{
-	public:
-		// Debug drawing API functions
-		virtual void DrawLine(const RE::NiPoint3& a_start, const RE::NiPoint3& a_end, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
-		virtual void DrawPoint(const RE::NiPoint3& a_position, float a_size, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF) noexcept = 0;
-		virtual void DrawArrow(const RE::NiPoint3& a_start, const RE::NiPoint3& a_end, float a_size = 10.f, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
-		virtual void DrawBox(const RE::NiPoint3& a_center, const RE::NiPoint3& a_extent, const RE::NiQuaternion& a_rotation, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
-		virtual void DrawCircle(const RE::NiPoint3& a_center, const RE::NiPoint3& a_x, const RE::NiPoint3& a_y, float a_radius, uint32_t a_segments, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
-		virtual void DrawHalfCircle(const RE::NiPoint3& a_center, const RE::NiPoint3& a_x, const RE::NiPoint3& a_y, float a_radius, uint32_t a_segments, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
-		virtual void DrawSphere(const RE::NiPoint3& a_origin, float a_radius, uint32_t a_segments = 16, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
-		virtual void DrawCylinder(const RE::NiPoint3& a_start, const RE::NiPoint3& a_end, float a_radius, uint32_t a_segments, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
-		virtual void DrawCone(const RE::NiPoint3& a_origin, const RE::NiPoint3& a_direction, float a_length, float a_angleWidth, float a_angleHeight, uint32_t a_segments, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
-		virtual void DrawCapsule(const RE::NiPoint3& a_origin, float a_halfHeight, float a_radius, const RE::NiQuaternion& a_rotation, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
+    class IVTrueHUD3 : public IVTrueHUD2 {
+    public:
+        // Debug drawing API functions
+        virtual void DrawLine(const RE::NiPoint3& a_start, const RE::NiPoint3& a_end, float a_duration = 0.f,
+                              uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
+        virtual void DrawPoint(const RE::NiPoint3& a_position, float a_size, float a_duration = 0.f,
+                               uint32_t a_color = 0xFF0000FF) noexcept = 0;
+        virtual void DrawArrow(const RE::NiPoint3& a_start, const RE::NiPoint3& a_end, float a_size = 10.f,
+                               float a_duration = 0.f, uint32_t a_color = 0xFF0000FF,
+                               float a_thickness = 1.f) noexcept = 0;
+        virtual void DrawBox(const RE::NiPoint3& a_center, const RE::NiPoint3& a_extent,
+                             const RE::NiQuaternion& a_rotation, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF,
+                             float a_thickness = 1.f) noexcept = 0;
+        virtual void DrawCircle(const RE::NiPoint3& a_center, const RE::NiPoint3& a_x, const RE::NiPoint3& a_y,
+                                float a_radius, uint32_t a_segments, float a_duration = 0.f,
+                                uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
+        virtual void DrawHalfCircle(const RE::NiPoint3& a_center, const RE::NiPoint3& a_x, const RE::NiPoint3& a_y,
+                                    float a_radius, uint32_t a_segments, float a_duration = 0.f,
+                                    uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
+        virtual void DrawSphere(const RE::NiPoint3& a_origin, float a_radius, uint32_t a_segments = 16,
+                                float a_duration = 0.f, uint32_t a_color = 0xFF0000FF,
+                                float a_thickness = 1.f) noexcept = 0;
+        virtual void DrawCylinder(const RE::NiPoint3& a_start, const RE::NiPoint3& a_end, float a_radius,
+                                  uint32_t a_segments, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF,
+                                  float a_thickness = 1.f) noexcept = 0;
+        virtual void DrawCone(const RE::NiPoint3& a_origin, const RE::NiPoint3& a_direction, float a_length,
+                              float a_angleWidth, float a_angleHeight, uint32_t a_segments, float a_duration = 0.f,
+                              uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
+        virtual void DrawCapsule(const RE::NiPoint3& a_origin, float a_halfHeight, float a_radius,
+                                 const RE::NiQuaternion& a_rotation, float a_duration = 0.f,
+                                 uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
 
-		/// <summary>
-		/// Get whether an info bar already exists for this actor.
-		/// </summary>
-		/// <param name="a_actorHandle">Actor handle</param>
-		/// <param name="a_bFloatingOnly">Only return true if the bar is a floating one</param>
-		/// <returns>Whether the bar exists or not</returns>
-		[[nodiscard]] virtual bool HasInfoBar(RE::ActorHandle a_actorHandle, bool a_bFloatingOnly = false) const noexcept = 0;
-	};
+        /// <summary>
+        /// Get whether an info bar already exists for this actor.
+        /// </summary>
+        /// <param name="a_actorHandle">Actor handle</param>
+        /// <param name="a_bFloatingOnly">Only return true if the bar is a floating one</param>
+        /// <returns>Whether the bar exists or not</returns>
+        [[nodiscard]] virtual bool HasInfoBar(RE::ActorHandle a_actorHandle,
+                                              bool a_bFloatingOnly = false) const noexcept = 0;
+    };
 
-	class IVTrueHUD4 : public IVTrueHUD3
-	{
-	public:
-		// Debug drawing API functions
-		virtual void DrawCapsule(const RE::NiPoint3& a_vertexA, const RE::NiPoint3& a_vertexB, float a_radius, float a_duration = 0.f, uint32_t a_color = 0xFF0000FF, float a_thickness = 1.f) noexcept = 0;
-	};
+    class IVTrueHUD4 : public IVTrueHUD3 {
+    public:
+        // Debug drawing API functions
+        virtual void DrawCapsule(const RE::NiPoint3& a_vertexA, const RE::NiPoint3& a_vertexB, float a_radius,
+                                 float a_duration = 0.f, uint32_t a_color = 0xFF0000FF,
+                                 float a_thickness = 1.f) noexcept = 0;
+    };
 
-	typedef void* (*_RequestPluginAPI)(const InterfaceVersion interfaceVersion);
+    typedef void* (*_RequestPluginAPI)(const InterfaceVersion interfaceVersion);
 
-	/// <summary>
-	/// Request the True HUD API interface.
-	/// Recommended: Send your request during or after SKSEMessagingInterface::kMessage_PostLoad to make sure the dll has already been loaded
-	/// </summary>
-	/// <param name="a_interfaceVersion">The interface version to request</param>
-	/// <returns>The pointer to the API singleton, or nullptr if request failed</returns>
-	[[nodiscard]] inline void* RequestPluginAPI(const InterfaceVersion a_interfaceVersion = InterfaceVersion::V4)
-	{
-		auto pluginHandle = GetModuleHandle("TrueHUD.dll");
-		_RequestPluginAPI requestAPIFunction = (_RequestPluginAPI)GetProcAddress(pluginHandle, "RequestPluginAPI");
-		if (requestAPIFunction) {
-			return requestAPIFunction(a_interfaceVersion);
-		}
-		return nullptr;
-	}
+    /// <summary>
+    /// Request the True HUD API interface.
+    /// Recommended: Send your request during or after SKSEMessagingInterface::kMessage_PostLoad to make sure the dll
+    /// has already been loaded
+    /// </summary>
+    /// <param name="a_interfaceVersion">The interface version to request</param>
+    /// <returns>The pointer to the API singleton, or nullptr if request failed</returns>
+    [[nodiscard]] inline void* RequestPluginAPI(const InterfaceVersion a_interfaceVersion = InterfaceVersion::V4) {
+        auto pluginHandle = GetModuleHandle("TrueHUD.dll");
+        auto requestAPIFunction = (_RequestPluginAPI)GetProcAddress(pluginHandle, "RequestPluginAPI");
+        if (requestAPIFunction) {
+            return requestAPIFunction(a_interfaceVersion);
+        }
+        return nullptr;
+    }
 }

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -30,14 +30,16 @@ namespace ERF {
         CSimpleIniA ini;
         ini.SetUnicode();
         const auto path = IniPath();
-        SI_Error rc = ini.LoadFile(path.string().c_str());
-        if (rc < 0) {
+
+        if (SI_Error rc = ini.LoadFile(path.string().c_str()); rc < 0) {
             return;
         }
         bool en = loadBool(ini, "General", "Enabled", true);
         enabled.store(en, std::memory_order_relaxed);
         bool hud = loadBool(ini, "HUD", "Enabled", true);
         hudEnabled.store(hud, std::memory_order_relaxed);
+        bool single = loadBool(ini, "Gauges", "Single", true);
+        isSingle.store(single, std::memory_order_relaxed);
     }
 
     void Config::Save() const {
@@ -45,8 +47,11 @@ namespace ERF {
         ini.SetUnicode();
         const auto path = IniPath();
         ini.LoadFile(path.string().c_str());
+
         ini.SetBoolValue("General", "Enabled", enabled.load(std::memory_order_relaxed));
         ini.SetBoolValue("HUD", "Enabled", hudEnabled.load(std::memory_order_relaxed));
+        ini.SetBoolValue("Gauges", "Single", isSingle.load(std::memory_order_relaxed));
+
         std::error_code ec;
         std::filesystem::create_directories(path.parent_path(), ec);
         ini.SaveFile(path.string().c_str());

--- a/src/Config.h
+++ b/src/Config.h
@@ -6,6 +6,7 @@ namespace ERF {
     struct Config {
         std::atomic<bool> enabled{true};
         std::atomic<bool> hudEnabled{true};
+        std::atomic<bool> isSingle{true};
 
         void Load();
         void Save() const;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -33,7 +33,7 @@ namespace {
         const RE::FormID key = a->GetFormID();
         if (auto it = g_headCache.find(key); it != g_headCache.end()) {
             if (RE::NiAVObject* n = it->second.node) {
-                if (n->parent) return n;  // válido
+                if (n->parent) return n;
                 if (RE::NiAVObject* root = a->Get3D2()) {
                     if (RE::NiAVObject* head = FindHeadNode(root)) {
                         it->second.node = head;
@@ -66,11 +66,11 @@ namespace {
 
 bool Utils::GetHeadPosFast(RE::Actor* a, RE::NiPoint3& out) {
     if (!a) return false;
-    if (RE::NiAVObject* head = GetHeadNodeFast_(a)) {
+    if (RE::NiAVObject const* head = GetHeadNodeFast_(a)) {
         out = head->world.translate;
         return true;
     }
-    if (RE::NiAVObject* root = a->Get3D2()) {
+    if (RE::NiAVObject const* root = a->Get3D2()) {
         const auto& b = root->worldBound;
         if (b.radius > 1e-4f) {
             out = b.center;
@@ -87,7 +87,7 @@ bool Utils::GetNodePosition(RE::ActorPtr a_actor, const char* a_nodeName, RE::Ni
     if (!root) return false;
     static thread_local RE::BSFixedString s_name;
     s_name = a_nodeName;
-    if (RE::NiAVObject* node = root->GetObjectByName(s_name)) {
+    if (RE::NiAVObject const* node = root->GetObjectByName(s_name)) {
         point = node->world.translate;
         return true;
     }
@@ -139,7 +139,6 @@ bool Utils::GetTargetPos(RE::ObjectRefHandle a_target, RE::NiPoint3& pos, bool b
     return true;
 }
 
-// === Helpers de gerenciamento do cache ===
 void Utils::HeadCacheReserve(std::size_t n) noexcept {
     EnsureReserveOnce();
     if (n > g_headCache.bucket_count()) g_headCache.reserve(n);

--- a/src/elemental_reactions/erf_preeffect.h
+++ b/src/elemental_reactions/erf_preeffect.h
@@ -38,8 +38,7 @@ public:
 
     std::span<const ERF_PreEffectHandle> listByElement(ERF_ElementHandle h) const;
 
-    // === NOVO: congelamento e introspecção ===
-    void freeze();  // sela o registry (impede novos registros)
+    void freeze();
     bool isFrozen() const noexcept { return _frozen; }
     std::size_t size() const noexcept { return (_effects.size() > 0) ? (_effects.size() - 1) : 0; }
 

--- a/src/elemental_reactions/erf_reaction.cpp
+++ b/src/elemental_reactions/erf_reaction.cpp
@@ -87,7 +87,6 @@ std::optional<ERF_ReactionHandle> ReactionRegistry::pickBest_core(const std::vec
                                                                   float invSumAll, const ReactionRegistry* self) {
     self->buildIndex_();
 
-    // 1) máscara dos presentes (você já fazia)
     ReactionRegistry::Mask presentMask = 0;
     for (auto h : present) {
         if (!h) continue;
@@ -146,21 +145,17 @@ std::optional<ERF_ReactionHandle> ReactionRegistry::pickBest_core(const std::vec
                 bestK = k;
                 bestH = h;
 
-                // early-stop: score perfeito
                 if (bestScore >= 1.0f - 1e-6f) return;
             }
         }
     };
 
-    // 2) Bucket EXATO primeiro — caminho feliz
     evalBucket(presentMask);
     if (bestH != 0 && bestScore >= 1.0f - 1e-6f) return bestH;
 
-    // 3) Submáscaras — com poda por cardinalidade
     for (auto sub = presentMask; sub; sub = (sub - 1) & presentMask) {
         if (sub == presentMask) continue;
-        const int k = popcount64(sub);
-        if (k < 2) continue;  // se 1-elem não é considerado, isso reduz muito a enumeração
+        if (const int k = popcount64(sub); k < 2) continue;
 
         evalBucket(sub);
         if (bestH != 0 && bestScore >= 1.0f - 1e-6f) break;

--- a/src/hud/HUDTick.cpp
+++ b/src/hud/HUDTick.cpp
@@ -35,7 +35,7 @@ namespace {
     static constexpr float EVICT_SECONDS = 10.0f;
 
     void UpdateAllOnUIThread() {
-        const double nowRt = InjectHUD::NowRtS();  // sua função steady_clock
+        const double nowRt = InjectHUD::NowRtS();
         const float nowH = RE::Calendar::GetSingleton()->GetHoursPassed();
         InjectHUD::OnUIFrameBegin(nowRt, nowH);
 
@@ -100,11 +100,10 @@ namespace {
                 const float seen = lastSeen.contains(id) ? lastSeen[id] : 0.0f;
                 const float age = now - seen;
 
-                // Esconder rápido para evitar churn de alocação
                 if (age >= ZERO_GRACE_SECONDS) {
                     InjectHUD::HideFor(id);
                 }
-                // Destruir só depois de um tempo maior de inatividade
+
                 if (age >= EVICT_SECONDS) {
                     toRemove.push_back(id);
                     lastAddedAt.erase(id);
@@ -125,7 +124,6 @@ namespace {
             const bool aliveNow = (alive.find(id) != alive.end());
             const float age = now - it->second;
 
-            // Se já não há entry e passou do grace, limpe tracking
             if (!aliveNow && !hasEntry && age >= ZERO_GRACE_SECONDS) {
                 lastAddedAt.erase(id);
                 it = lastSeen.erase(it);

--- a/src/hud/InjectHUD.h
+++ b/src/hud/InjectHUD.h
@@ -87,7 +87,6 @@ namespace InjectHUD {
 
         void FollowActorHead(RE::Actor* actor);
 
-        // Chamada única por ator/por frame para desenhar tudo
         void SetAll(const std::vector<double>& comboRemain01, const std::vector<std::uint32_t>& comboTintsRGB,
                     const std::vector<double>& accumValues, const std::vector<std::uint32_t>& accumColorsRGB);
 
@@ -95,35 +94,29 @@ namespace InjectHUD {
         void ClearAndHide();
 
     private:
-        // ===== Issue 7: cache GFx para evitar CreateArray/Push por frame =====
         bool _arraysInit{false};
 
-        // Arrays persistentes usados em setAll (reutilizados frame a frame)
         RE::GFxValue _arrComboRemain;
         RE::GFxValue _arrComboTints;
         RE::GFxValue _arrAccumVals;
         RE::GFxValue _arrAccumCols;
+        RE::GFxValue _isSingle;
 
-        // Vetor de argumentos fixo (sempre aponta para os membros acima)
-        RE::GFxValue _args[4];
+        RE::GFxValue _args[5];
 
-        // Helpers para inicializar e preencher sem alocar todo frame
         void EnsureArrays();
         void FillArrayDoubles(RE::GFxValue& arr, const std::vector<double>& src);
         void FillArrayU32AsNumber(RE::GFxValue& arr, const std::vector<std::uint32_t>& src);
     };
 
-    // Gerência do ciclo de vida do widget por ator
     void AddFor(RE::Actor* actor);
     void UpdateFor(RE::Actor* actor, double nowRtS, float nowH);
     void BeginReaction(RE::Actor* a, ERF_ReactionHandle handle, float seconds, bool realTime);
 
-    // Issue 6: ocultar (reutilizar) vs remover (evict definitivo)
     bool HideFor(RE::FormID id);
     bool RemoveFor(RE::FormID id);
     void RemoveAllWidgets();
 
-    // Eventos do TrueHUD/loop de UI
     void OnTrueHUDClose();
     void OnUIFrameBegin(double nowRtS, float nowH);
 

--- a/src/ui/ERF_UI.cpp
+++ b/src/ui/ERF_UI.cpp
@@ -15,10 +15,24 @@ void __stdcall ERF_UI::DrawGeneral() {
 
     ImGui::Separator();
 
-    bool hud = ERF::GetConfig().hudEnabled.load(std::memory_order_relaxed);
-    if (ImGui::Checkbox("Show HUD", &hud)) {
+    if (bool hud = ERF::GetConfig().hudEnabled.load(std::memory_order_relaxed); ImGui::Checkbox("Show HUD", &hud)) {
         ERF::GetConfig().hudEnabled.store(hud, std::memory_order_relaxed);
         ERF::GetConfig().Save();
+    }
+
+    int modeIndex = ERF::GetConfig().isSingle.load(std::memory_order_relaxed) ? 0 : 1;
+    const char* kModes[] = {"Single", "Mixed"};
+    auto count = (int)(sizeof(kModes) / sizeof(kModes[0]));
+    ImGui::SetNextItemWidth(180.0f);
+    if (ImGui::Combo("Gauge mode", &modeIndex, kModes, count)) {
+        ERF::GetConfig().isSingle.store(modeIndex == 0, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip(
+            "Single: An accumulator for each element.\n"
+            "Mixed: Combines different elements into the same accumulator.");
     }
 }
 


### PR DESCRIPTION
Adicionei uma nova opção para o meu para trocar entre single e mixed para reações. No modo single ele vai criar um gauge por elemento e vai ativar a reação quando um elemento chegar a 100 pontos. No modo mixed vai ativar a reação quando a combinação de todos os elementos atingir 100 pontos.

## Summary by Sourcery

Add 'single' vs 'mixed' gauge mode toggle for elemental reaction system and HUD rendering

New Features:
- Introduce a new Config setting 'isSingle' controlling gauge mode
- Add UI combo box to switch between Single and Mixed gauge modes with tooltip
- Extend HUD widget to accept the mode flag and render gauges accordingly
- Branch reaction-triggering logic to fire per-element in Single mode or combined in Mixed mode

Enhancements:
- Refactor TriggerReaction to accept an element handle parameter for mode-specific triggering
- Update ElementalGauges and InjectHUD to load, save, and propagate the gauge mode flag

Documentation:
- Add tooltip in UI explaining Single vs Mixed modes