### PR TITLE
feat(Menu): :sparkles: Configurar multiplicador de gauge

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -7,6 +7,8 @@ namespace ERF {
         std::atomic<bool> enabled{true};
         std::atomic<bool> hudEnabled{true};
         std::atomic<bool> isSingle{true};
+        std::atomic<float> playerMult{1.0};
+        std::atomic<float> npcMult{1.0};
 
         void Load();
         void Save() const;

--- a/src/ui/ERF_UI.cpp
+++ b/src/ui/ERF_UI.cpp
@@ -34,6 +34,27 @@ void __stdcall ERF_UI::DrawGeneral() {
             "Single: An accumulator for each element.\n"
             "Mixed: Combines different elements into the same accumulator.");
     }
+
+    ImGui::Separator();
+
+    float pm = ERF::GetConfig().playerMult.load(std::memory_order_relaxed);
+    ImGui::SetNextItemWidth(240.0f);
+    if (ImGui::InputFloat("Player gauge multiplier", &pm, 0.1f, 1.0f, "%.3f")) {
+        if (pm < 0.f) pm = 0.f;
+        ERF::GetConfig().playerMult.store(pm, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Multiplies the player's gauge gain/loss. E.g.: 2.0 = doubles, 0.5 = halves.");
+
+    float nm = ERF::GetConfig().npcMult.load(std::memory_order_relaxed);
+    ImGui::SetNextItemWidth(240.0f);
+    if (ImGui::InputFloat("NPC gauge multiplier", &nm, 0.1f, 1.0f, "%.3f")) {
+        if (nm < 0.f) nm = 0.f;
+        ERF::GetConfig().npcMult.store(nm, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Multiplies the NPCs' gauge gain/loss.");
 }
 
 void ERF_UI::Register() {


### PR DESCRIPTION
Adicionei duas opções para configurar os multiplicadores de gauge para PC ou NPC de forma a afetar a taxa de ganho de gauge para mais ou para menos

## Summary by Sourcery

Add configurable gauge gain multipliers for player and NPC and integrate them into the UI and gauge calculation

New Features:
- Introduce PlayerMult and NpcMult settings in the Gauges section of the INI
- Expose input fields for player and NPC gauge multipliers in the ERF UI menu
- Apply the configured multipliers when computing gauge changes in ElementalGauges::Add

Enhancements:
- Add a loadDouble helper to read floating values from the INI
- Refactor various static_casts and conditional checks using C++17 if-with-init for clarity