### PR TITLE
fix(HUD): :bug: Corrigido a posição do gauge do player

### DIFF
--- a/src/hud/InjectHUD.cpp
+++ b/src/hud/InjectHUD.cpp
@@ -79,21 +79,17 @@ namespace {
         return out;
     }
 
-    inline bool IsPlayerActor(RE::Actor* a) {
-        auto* pc = RE::PlayerCharacter::GetSingleton();
-        return a && pc && (a == pc);
-    }
+    inline bool IsPlayerActor(RE::Actor* a) { return a && a->IsPlayerRef(); }
 
     void FollowPlayerFixed(InjectHUD::ERFWidget& w) {
         if (!w._view) {
             return;
         }
-        RE::GRectF rect = w._view->GetVisibleFrameRect();
-        const double baseX = rect.left + InjectHUD::ERFWidget::kPlayerMarginLeftPx;
-        const double baseY = rect.bottom - InjectHUD::ERFWidget::kPlayerMarginBottomPx;
 
-        const double targetX = baseX;
-        const double targetY = baseY;
+        spdlog::info("[ERF HUD] FollowPlayerFixed");
+        RE::GRectF rect = w._view->GetVisibleFrameRect();
+        const double targetX = rect.left + InjectHUD::ERFWidget::kPlayerMarginLeftPx;
+        const double targetY = rect.bottom - InjectHUD::ERFWidget::kPlayerMarginBottomPx;
 
         if (w._needsSnap || std::isnan(w._lastX) || std::isnan(w._lastY)) {
             w._lastX = targetX;
@@ -130,8 +126,6 @@ void InjectHUD::ERFWidget::Initialize() {
 
     _needsSnap = true;
     ResetSmoothing();
-    _hadContent = false;
-    _lastGaugeRtS = std::numeric_limits<double>::quiet_NaN();
 
     _arraysInit = false;
     EnsureArrays();
@@ -345,7 +339,6 @@ void InjectHUD::AddFor(RE::Actor* actor) {
     }
 
     const auto h = actor->GetHandle();
-    g_trueHUD->AddActorInfoBar(h);
 
     auto w = std::make_shared<ERFWidget>();
     const auto wid = actor->GetFormID();
@@ -380,7 +373,6 @@ void InjectHUD::UpdateFor(RE::Actor* actor, double nowRt, float nowH) {
     }
 
     const auto h = actor->GetHandle();
-    g_trueHUD->AddActorInfoBar(h);
 
     std::vector<double> comboRemain01;
     std::vector<std::uint32_t> comboTintsRGB;

--- a/src/hud/InjectHUD.h
+++ b/src/hud/InjectHUD.h
@@ -65,20 +65,8 @@ namespace InjectHUD {
         double _lastX{std::numeric_limits<double>::quiet_NaN()};
         double _lastY{std::numeric_limits<double>::quiet_NaN()};
 
-        bool _hadContent{false};
-        double _lastGaugeRtS{std::numeric_limits<double>::quiet_NaN()};
-
-        double _risePerSec = 90.0;
-        double _fallPerSec = 600.0;
-        double _comboPerSec = 2.5;
-
-        Smooth01 _fireDisp{};
-        Smooth01 _frostDisp{};
-        Smooth01 _shockDisp{};
-        Smooth01 _comboDisp{};
-
-        static constexpr float kPlayerMarginLeftPx = 45.0f;
-        static constexpr float kPlayerMarginBottomPx = 160.0f;
+        static constexpr float kPlayerMarginLeftPx = 180.0f;
+        static constexpr float kPlayerMarginBottomPx = 120.0f;
         static constexpr float kPlayerScale = 1.5f;
 
         void Initialize() override;


### PR DESCRIPTION
Movi o gauge do player um pouco para baixo e mais para a direita para ficar melhor ajustado sobre a barra de vida

## Summary by Sourcery

Fix the player gauge positioning and clean up HUD injection code.

Bug Fixes:
- Adjust the player gauge margins to reposition it correctly over the health bar

Enhancements:
- Simplify IsPlayerActor by using IsPlayerRef()
- Add logging in FollowPlayerFixed for HUD debug tracing
- Remove unused state variables (_hadContent, _lastGaugeRtS) and redundant AddActorInfoBar calls