### PR TITLE
fix(Reaction): :bug: Corrigido um bug em que reações não eram ativada…

### DIFF
--- a/src/elemental_reactions/erf_reaction.cpp
+++ b/src/elemental_reactions/erf_reaction.cpp
@@ -155,7 +155,6 @@ std::optional<ERF_ReactionHandle> ReactionRegistry::pickBest_core(const std::vec
 
     for (auto sub = presentMask; sub; sub = (sub - 1) & presentMask) {
         if (sub == presentMask) continue;
-        if (const int k = popcount64(sub); k < 2) continue;
 
         evalBucket(sub);
         if (bestH != 0 && bestScore >= 1.0f - 1e-6f) break;


### PR DESCRIPTION
…s mesmo atendendo as condições

as vezes ele não ativava reações mesmo quando atendia as condições devido a ausencia de fallback para backets de tamanho menor ao bucket de reações que estava sendo acessado

## Summary by Sourcery

Bug Fixes:
- Remove the popcount filter that skipped sub-buckets with fewer than two bits to restore fallback handling for smaller buckets