### PR TITLE
fix(HUD): :bug: Corrigido problema do gauge em modo single ficar semp…

### DIFF
--- a/src/elemental_reactions/ElementalGauges.cpp
+++ b/src/elemental_reactions/ElementalGauges.cpp
@@ -846,21 +846,27 @@ std::optional<ElementalGauges::HudGaugeBundle> ElementalGauges::PickHudDecayed(R
 
     HudGaugeBundle bundle{};
 
-    const std::size_t beginE = Gauges::firstIndex();
-    const std::size_t nE = e.v.size();
-    const std::size_t countE = (nE > beginE) ? (nE - beginE) : 0;
-
-    TL_vals32.resize(countE);
-    TL_cols32.resize(countE);
+    TL_vals32.clear();
+    TL_cols32.clear();
+    TL_vals32.reserve(e.presentList.size());
+    TL_cols32.reserve(e.presentList.size());
 
     const auto colors = GetColorLUT();
+    const std::size_t beginE = Gauges::firstIndex();
 
     int newSum = 0;
-    for (std::size_t i = beginE, j = 0; i < nE; ++i, ++j) {
+    for (ERF_ElementHandle h : e.presentList) {
+        const std::size_t i = Gauges::idx(h);
+        if (i >= e.v.size()) continue;
         const std::uint8_t vv = e.v[i];
-        TL_vals32[j] = static_cast<std::uint32_t>(vv);
-        TL_cols32[j] = (i < colors.size()) ? colors[i] : 0xFFFFFFu;
+        if (vv == 0) continue;
+
         newSum += vv;
+        TL_vals32.push_back(static_cast<std::uint32_t>(vv));
+
+        const std::size_t colorIdx = i;
+        const std::uint32_t rgb = (colorIdx < colors.size()) ? colors[colorIdx] : 0xFFFFFFu;
+        TL_cols32.push_back(rgb);
     }
 
     bundle.values = std::span<const std::uint32_t>(TL_vals32.data(), TL_vals32.size());


### PR DESCRIPTION
…re na mesma ordem

Quando estava em modo single, os gauge sempre eram criados na mesma ordem. Isso levava a situações de um novo gauge ser colocado a esquerda e empurrar um gauge a direita. Isso foi corrigido ao construir o vetor de valores na ordem de presentList ao invés da ordem de registro dos elementos

## Summary by Sourcery

Fix HUD gauge display to preserve the intended order by constructing gauge data from presentList in single mode and omitting zero-value entries.

Bug Fixes:
- Fix HUD gauge ordering in single mode to match presentList sequence

Enhancements:
- Build gauge value and color arrays by iterating presentList and skipping zero values
- Use clear and reserve for value and color vectors instead of resize