### PR TITLE
feat: :sparkles: Configuraçoes para mudar a posição do gauge na tela …

### DIFF
--- a/build_swf.bat
+++ b/build_swf.bat
@@ -9,7 +9,7 @@ rem === Pastas/arquivos ===
 set "SRC=flash\src"
 set "OUT=build"
 set "DIST=Interface\erfgauge"
-set "MO2=D:\MO2\mods\ElementalReactionsFramework\Interface\erfgauge"
+set "MO2=D:\ModdingSkyrim\MO2\mods\ElementalReactionsFramework\Interface\erfgauge"
 
 rem Templates
 set "GAUGE_XML=flash\gauge_template.xml"
@@ -28,7 +28,7 @@ rem 2) Compila a logica (AS2) em cima do base
 "%MTASC%" -version 8 -cp "%SRC%" -swf "%GAUGE_BASE%" -frame 1 -main "Register.as" -out "%GAUGE_OUT%" "%SRC%\ERF_Gauge.as" || goto :err
 
 rem 4) Copia DDS para MO2 (se existir)
-if exist "D:\MO2\mods" (
+if exist "D:\ModdingSkyrim\MO2\mods" (
   if not exist "%MO2%" mkdir "%MO2%"
   copy /Y "%GAUGE_OUT%" "%MO2%\erfgauge.swf" >nul
 )

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -46,12 +46,32 @@ namespace ERF {
         bool sgl = loadBool(ini, "Gauges", "Single", true);
         double pm = loadDouble(ini, "Gauges", "PlayerMult", 1.0);
         double nm = loadDouble(ini, "Gauges", "NpcMult", 1.0);
+        double px = loadDouble(ini, "HUD", "PlayerXPosition", 0.0);
+        double py = loadDouble(ini, "HUD", "PlayerYPosition", 0.0);
+        double nx = loadDouble(ini, "HUD", "NpcXPosition", 0.0);
+        double ny = loadDouble(ini, "HUD", "NpcYPosition", 0.0);
+        double psc = loadDouble(ini, "HUD", "PlayerScale", 1.0);
+        double nsc = loadDouble(ini, "HUD", "NpcScale", 1.0);
+        bool ph = loadBool(ini, "HUD", "PlayerHorizontal", true);
+        bool nh = loadBool(ini, "HUD", "NpcHorizontal", true);
+        double psp = loadDouble(ini, "HUD", "PlayerSpacing", 40.0);
+        double nsp = loadDouble(ini, "HUD", "NpcSpacing", 40.0);
 
         enabled.store(en, std::memory_order_relaxed);
         hudEnabled.store(hud, std::memory_order_relaxed);
         isSingle.store(sgl, std::memory_order_relaxed);
         playerMult.store(static_cast<float>(pm < 0 ? 0 : pm), std::memory_order_relaxed);
         npcMult.store(static_cast<float>(nm < 0 ? 0 : nm), std::memory_order_relaxed);
+        playerXPosition.store(static_cast<float>(px), std::memory_order_relaxed);
+        playerYPosition.store(static_cast<float>(py), std::memory_order_relaxed);
+        npcXPosition.store(static_cast<float>(nx), std::memory_order_relaxed);
+        npcYPosition.store(static_cast<float>(ny), std::memory_order_relaxed);
+        playerScale.store(static_cast<float>(psc > 0 ? psc : 1.0), std::memory_order_relaxed);
+        npcScale.store(static_cast<float>(nsc > 0 ? nsc : 1.0), std::memory_order_relaxed);
+        playerHorizontal.store(ph, std::memory_order_relaxed);
+        npcHorizontal.store(nh, std::memory_order_relaxed);
+        playerSpacing.store(static_cast<float>(psp < 0 ? 0 : psp), std::memory_order_relaxed);
+        npcSpacing.store(static_cast<float>(nsp < 0 ? 0 : nsp), std::memory_order_relaxed);
     }
 
     void Config::Save() const {
@@ -65,6 +85,16 @@ namespace ERF {
         ini.SetBoolValue("Gauges", "Single", isSingle.load(std::memory_order_relaxed));
         ini.SetDoubleValue("Gauges", "PlayerMult", playerMult.load(std::memory_order_relaxed));
         ini.SetDoubleValue("Gauges", "NpcMult", npcMult.load(std::memory_order_relaxed));
+        ini.SetDoubleValue("HUD", "PlayerXPosition", playerXPosition.load(std::memory_order_relaxed));
+        ini.SetDoubleValue("HUD", "PlayerYPosition", playerYPosition.load(std::memory_order_relaxed));
+        ini.SetDoubleValue("HUD", "NpcXPosition", npcXPosition.load(std::memory_order_relaxed));
+        ini.SetDoubleValue("HUD", "NpcYPosition", npcYPosition.load(std::memory_order_relaxed));
+        ini.SetDoubleValue("HUD", "PlayerScale", playerScale.load(std::memory_order_relaxed));
+        ini.SetDoubleValue("HUD", "NpcScale", npcScale.load(std::memory_order_relaxed));
+        ini.SetBoolValue("HUD", "PlayerHorizontal", playerHorizontal.load(std::memory_order_relaxed));
+        ini.SetBoolValue("HUD", "NpcHorizontal", npcHorizontal.load(std::memory_order_relaxed));
+        ini.SetDoubleValue("HUD", "PlayerSpacing", playerSpacing.load(std::memory_order_relaxed));
+        ini.SetDoubleValue("HUD", "NpcSpacing", npcSpacing.load(std::memory_order_relaxed));
 
         std::error_code ec;
         std::filesystem::create_directories(path.parent_path(), ec);

--- a/src/Config.h
+++ b/src/Config.h
@@ -10,6 +10,17 @@ namespace ERF {
         std::atomic<float> playerMult{1.0};
         std::atomic<float> npcMult{1.0};
 
+        std::atomic<float> playerXPosition{0.0};
+        std::atomic<float> playerYPosition{0.0};
+        std::atomic<float> npcXPosition{0.0};
+        std::atomic<float> npcYPosition{0.0};
+        std::atomic<float> playerScale{1.0};
+        std::atomic<float> npcScale{1.0};
+        std::atomic<bool> playerHorizontal{true};
+        std::atomic<bool> npcHorizontal{true};
+        std::atomic<float> playerSpacing{40.0};
+        std::atomic<float> npcSpacing{40.0};
+
         void Load();
         void Save() const;
 

--- a/src/hud/InjectHUD.h
+++ b/src/hud/InjectHUD.h
@@ -62,6 +62,8 @@ namespace InjectHUD {
 
         bool _needsSnap = true;
 
+        bool _isPlayerWidget = false;
+
         double _lastX{std::numeric_limits<double>::quiet_NaN()};
         double _lastY{std::numeric_limits<double>::quiet_NaN()};
 
@@ -89,8 +91,10 @@ namespace InjectHUD {
         RE::GFxValue _arrAccumVals;
         RE::GFxValue _arrAccumCols;
         RE::GFxValue _isSingle;
+        RE::GFxValue _isHorin;
+        RE::GFxValue _spacing;
 
-        RE::GFxValue _args[5];
+        RE::GFxValue _args[7];
 
         void EnsureArrays();
         void FillArrayDoubles(RE::GFxValue& arr, const std::vector<double>& src);

--- a/src/ui/ERF_UI.cpp
+++ b/src/ui/ERF_UI.cpp
@@ -38,7 +38,7 @@ void __stdcall ERF_UI::DrawGeneral() {
     ImGui::Separator();
 
     float pm = ERF::GetConfig().playerMult.load(std::memory_order_relaxed);
-    ImGui::SetNextItemWidth(240.0f);
+    ImGui::SetNextItemWidth(200.0f);
     if (ImGui::InputFloat("Player gauge multiplier", &pm, 0.1f, 1.0f, "%.3f")) {
         if (pm < 0.f) pm = 0.f;
         ERF::GetConfig().playerMult.store(pm, std::memory_order_relaxed);
@@ -48,7 +48,7 @@ void __stdcall ERF_UI::DrawGeneral() {
         ImGui::SetTooltip("Multiplies the player's gauge gain/loss. E.g.: 2.0 = doubles, 0.5 = halves.");
 
     float nm = ERF::GetConfig().npcMult.load(std::memory_order_relaxed);
-    ImGui::SetNextItemWidth(240.0f);
+    ImGui::SetNextItemWidth(200.0f);
     if (ImGui::InputFloat("NPC gauge multiplier", &nm, 0.1f, 1.0f, "%.3f")) {
         if (nm < 0.f) nm = 0.f;
         ERF::GetConfig().npcMult.store(nm, std::memory_order_relaxed);
@@ -57,10 +57,117 @@ void __stdcall ERF_UI::DrawGeneral() {
     if (ImGui::IsItemHovered()) ImGui::SetTooltip("Multiplies the NPCs' gauge gain/loss.");
 }
 
+void __stdcall ERF_UI::DrawHUD() {
+    ImGui::TextUnformatted("HUD Settings");
+    ImGui::Separator();
+
+    ImGui::TextUnformatted("Player");
+    ImGui::Separator();
+
+    float x = ERF::GetConfig().playerXPosition.load(std::memory_order_relaxed);
+    ImGui::SetNextItemWidth(200.0f);
+    if (ImGui::InputFloat("X Position (px)##player", &x, 1.0f, 10.0f, "%.2f")) {
+        ERF::GetConfig().playerXPosition.store(x, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Positive values move the gauge to the right. Negative values move it to the left.");
+
+    float y = ERF::GetConfig().playerYPosition.load(std::memory_order_relaxed);
+    ImGui::SetNextItemWidth(200.0f);
+    if (ImGui::InputFloat("Y Position (px)##player", &y, 1.0f, 10.0f, "%.2f")) {
+        ERF::GetConfig().playerYPosition.store(y, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Positive values move the gauge up. Negative values move it down.");
+
+    float sc = ERF::GetConfig().playerScale.load(std::memory_order_relaxed);
+    ImGui::SetNextItemWidth(200.0f);
+    if (ImGui::InputFloat("Scale##player", &sc, 0.05f, 0.25f, "%.3f")) {
+        if (sc < 0.f) sc = 0.f;
+        ERF::GetConfig().playerScale.store(sc, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Gauge size.");
+
+    bool horiz = ERF::GetConfig().playerHorizontal.load(std::memory_order_relaxed);
+    int idx = horiz ? 0 : 1;
+    const char* opts[] = {"horizontally", "vertically"};
+    ImGui::SetNextItemWidth(260.0f);
+    if (ImGui::Combo("Align gauges:##player", &idx, opts, (int)(sizeof(opts) / sizeof(opts[0])))) {
+        ERF::GetConfig().playerHorizontal.store(idx == 0, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+
+    float psp = ERF::GetConfig().playerSpacing.load(std::memory_order_relaxed);
+    ImGui::SetNextItemWidth(200.0f);
+    if (ImGui::InputFloat("Spacing (px)##player", &psp, 1.0f, 5.0f, "%.1f")) {
+        if (psp < 0.f) psp = 0.f;
+        ERF::GetConfig().playerSpacing.store(psp, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Distance between the player's gauges in pixels.");
+    }
+
+    ImGui::Spacing();
+    ImGui::Separator();
+
+    ImGui::TextUnformatted("NPC");
+    ImGui::Separator();
+
+    float nx = ERF::GetConfig().npcXPosition.load(std::memory_order_relaxed);
+    ImGui::SetNextItemWidth(200.0f);
+    if (ImGui::InputFloat("X Position (px)##npc", &nx, 1.0f, 10.0f, "%.2f")) {
+        ERF::GetConfig().npcXPosition.store(nx, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Positive values move the gauge to the right. Negative values move it to the left.");
+
+    float ny = ERF::GetConfig().npcYPosition.load(std::memory_order_relaxed);
+    ImGui::SetNextItemWidth(200.0f);
+    if (ImGui::InputFloat("Y Position (px)##npc", &ny, 1.0f, 10.0f, "%.2f")) {
+        ERF::GetConfig().npcYPosition.store(ny, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Positive values move the gauge up. Negative values move it down.");
+
+    float nsc = ERF::GetConfig().npcScale.load(std::memory_order_relaxed);
+    ImGui::SetNextItemWidth(200.0f);
+    if (ImGui::InputFloat("Scale##npc", &nsc, 0.05f, 0.25f, "%.3f")) {
+        if (nsc < 0.f) nsc = 0.f;
+        ERF::GetConfig().npcScale.store(nsc, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Gauge size.");
+
+    bool nhoriz = ERF::GetConfig().npcHorizontal.load(std::memory_order_relaxed);
+    int nidx = nhoriz ? 0 : 1;
+    const char* nopts[] = {"horizontally", "vertically"};
+    ImGui::SetNextItemWidth(260.0f);
+    if (ImGui::Combo("Align gauges:##npc", &nidx, nopts, (int)(sizeof(nopts) / sizeof(nopts[0])))) {
+        ERF::GetConfig().npcHorizontal.store(nidx == 0, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+
+    float nsp = ERF::GetConfig().npcSpacing.load(std::memory_order_relaxed);
+    ImGui::SetNextItemWidth(200.0f);
+    if (ImGui::InputFloat("Spacing (px)##npc", &nsp, 1.0f, 5.0f, "%.1f")) {
+        if (nsp < 0.f) nsp = 0.f;
+        ERF::GetConfig().npcSpacing.store(nsp, std::memory_order_relaxed);
+        ERF::GetConfig().Save();
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Distance between the npc's gauges in pixels.");
+    }
+}
+
 void ERF_UI::Register() {
     if (!SKSEMenuFramework::IsInstalled()) return;
 
     SKSEMenuFramework::SetSection("Elemental Reactions");
 
     SKSEMenuFramework::AddSectionItem("General", ERF_UI::DrawGeneral);
+    SKSEMenuFramework::AddSectionItem("HUD", ERF_UI::DrawHUD);
 }

--- a/src/ui/ERF_UI.h
+++ b/src/ui/ERF_UI.h
@@ -4,5 +4,6 @@
 
 namespace ERF_UI {
     void __stdcall DrawGeneral();
+    void __stdcall DrawHUD();
     void Register();
 }


### PR DESCRIPTION
…para player e npcs

Adicionei uma série de novas configurações sendo elas: Adicionar um padding em X para o gauge. Adicionar um padding em Y para o gauge. Alterar a Escala do gauge. Alterar o espaçamento entre os gauges. Modificar se os gauges serão dispostos horizontalmente ou verticalmente. Todas essas configurações estão separadas em versão para o player e npcs

## Summary by Sourcery

Provide a new HUD configuration section allowing independent adjustment of player and NPC gauge position, size, spacing, and layout orientation, and update underlying gauge rendering logic and config persistence to support these options

New Features:
- Add HUD settings UI to configure player and NPC gauge X/Y position, scale, spacing, and orientation
- Extend AS gauge logic to accept orientation and spacing parameters and position slots accordingly
- Propagate HUD config through InjectHUD to adjust gauge placement and scale at runtime
- Persist new HUD settings in configuration ini and expose Save/Load functionality

Enhancements:
- Reduce ImGui input widths for gauge multiplier controls
- Fix batch build script MO2 path