### PR TITLE
feat(menu): :sparkles: Editar magnitudade de gauges em SKSE menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,16 @@ add_commonlibsse_plugin(ElementalReactionsFramework
     src/ModAPI.cpp
     src/ui/ERF_UI.cpp
     src/Config.cpp
+    src/overrides/Overrides.cpp
+)
+
+target_compile_definitions(ElementalReactionsFramework PRIVATE
+  SKYRIM_SUPPORT_AE
+  SKYRIM_SUPPORT_SE
 )
 
 target_include_directories(ElementalReactionsFramework
   PRIVATE
-  ${truehud_SOURCE_DIR}/src
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/src )
@@ -58,6 +63,7 @@ target_precompile_headers(ElementalReactionsFramework PRIVATE
   src/ui/ERF_UI.h
   src/Offsets.h
   src/Config.h
+  src/overrides/Overrides.h
 )
 
 if(DEFINED OUTPUT_FOLDER)

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -6,7 +6,7 @@
 #include <cctype>
 #include <string>
 
-namespace ERF {
+namespace {
     static bool loadBool(CSimpleIniA& ini, const char* sec, const char* key, bool defVal) {
         const char* val = ini.GetValue(sec, key, nullptr);
         if (!val) return defVal;
@@ -24,14 +24,23 @@ namespace ERF {
         double d = std::strtod(v, &end);
         return (end && *end == '\0') ? d : defVal;
     }
+}
+
+const std::filesystem::path& ERF_GetThisDllDir();
+
+namespace ERF {
 
     std::filesystem::path Config::IniPath() {
-        auto dirOpt = SKSE::log::log_directory();
-        if (!dirOpt) {
-            return std::filesystem::path("ElementalReactionsFramework.ini");
+        const auto& dllDir = ERF_GetThisDllDir();
+        if (!dllDir.empty()) {
+            return dllDir / "ERF" / "ElementalReactionsFramework.ini";
         }
-        auto p = *dirOpt / "ElementalReactionsFramework.ini";
-        return p;
+
+        if (auto dirOpt = SKSE::log::log_directory()) {
+            return *dirOpt / "ERF" / "ElementalReactionsFramework.ini";
+        }
+
+        return std::filesystem::path("Data") / "SKSE" / "Plugins" / "ERF" / "ElementalReactionsFramework.ini";
     }
 
     void Config::Load() {

--- a/src/ModAPI.cpp
+++ b/src/ModAPI.cpp
@@ -9,7 +9,6 @@
 #include "elemental_reactions/erf_preeffect.h"
 #include "elemental_reactions/erf_reaction.h"
 #include "elemental_reactions/erf_state.h"
-#include "spdlog/spdlog.h"
 
 namespace {
     std::atomic<int> g_reg_barrier{0};
@@ -32,7 +31,6 @@ namespace {
         g_caps.numStates = static_cast<std::uint16_t>(StateRegistry::get().size());
         g_caps.numReactions = static_cast<std::uint16_t>(ReactionRegistry::get().size());
         g_caps.ready = true;
-        spdlog::info("[ERF] Registries selados.");
     }
 }
 

--- a/src/elemental_reactions/ElementalGaugesHook.cpp
+++ b/src/elemental_reactions/ElementalGaugesHook.cpp
@@ -70,9 +70,6 @@ namespace {
 namespace GaugesHook {
     using Elem = ERF_ElementHandle;
 
-    static RE::BGSKeyword* g_kwGaugeAcc = nullptr;
-    static RE::EffectSetting* g_mgefGaugeAcc = nullptr;
-
     static StripedMap<std::uint64_t, double, 64> g_lastAccHint;
     static StripedMap<std::uint64_t, std::uint16_t, 64> g_lastAccCarrierUID;
 
@@ -90,11 +87,6 @@ namespace GaugesHook {
         return static_cast<std::uint64_t>(a ? a->GetFormID() : 0);
     }
 
-    static RE::BGSKeyword* LookupKW(const char* edid, std::uint32_t formID = 0) {
-        if (auto* k = RE::TESForm::LookupByEditorID<RE::BGSKeyword>(edid)) return k;
-        if (formID) return RE::TESForm::LookupByID<RE::BGSKeyword>(formID);
-        return nullptr;
-    }
     static RE::EffectSetting* LookupMGEF(const char* edid, std::uint32_t formID = 0) {
         if (auto* m = RE::TESForm::LookupByEditorID<RE::EffectSetting>(edid)) return m;
         if (formID) return RE::TESForm::LookupByID<RE::EffectSetting>(formID);
@@ -104,18 +96,8 @@ namespace GaugesHook {
     static bool IsGaugeAccCarrier(const RE::EffectSetting* mgef) {
         if (!mgef) return false;
 
-        if (g_mgefGaugeAcc && mgef == g_mgefGaugeAcc) {
+        if (ElementalGaugesHook::g_mgefGaugeAcc && mgef == ElementalGaugesHook::g_mgefGaugeAcc) {
             return true;
-        }
-
-        if (g_kwGaugeAcc) {
-            const auto kwIDWant = g_kwGaugeAcc->GetFormID();
-            for (auto* kw : mgef->GetKeywords()) {
-                const auto id = kw ? kw->GetFormID() : 0u;
-                if (kw && id == kwIDWant) {
-                    return true;
-                }
-            }
         }
         return false;
     }
@@ -384,19 +366,11 @@ void ElementalGaugesHook::InitCarrierRefs() {
     using namespace GaugesHook;
     static constexpr const char* kPlugin = "ERF_Keywords.esp";
     constexpr std::uint32_t kMgefLocalID = 0x0000C804;
-    constexpr std::uint32_t kKwLocalID = 0x000000;
 
     auto* dh = RE::TESDataHandler::GetSingleton();
 
     g_mgefGaugeAcc = dh ? dh->LookupForm<RE::EffectSetting>(kMgefLocalID, kPlugin) : nullptr;
     if (!g_mgefGaugeAcc) {
         g_mgefGaugeAcc = LookupMGEF("ERF_GaugeAccEffect");
-    }
-
-    if (kKwLocalID) {
-        g_kwGaugeAcc = dh ? dh->LookupForm<RE::BGSKeyword>(kKwLocalID, kPlugin) : nullptr;
-    }
-    if (!g_kwGaugeAcc) {
-        g_kwGaugeAcc = LookupKW("ERF_GaugeAccKW");
     }
 }

--- a/src/elemental_reactions/ElementalGaugesHook.h
+++ b/src/elemental_reactions/ElementalGaugesHook.h
@@ -7,6 +7,7 @@
 
 namespace ElementalGaugesHook {
     extern std::atomic_bool ALLOW_HUD_TICK;
+    static RE::EffectSetting* g_mgefGaugeAcc = nullptr;
     void StartHUDTick();
     void StopHUDTick();
     void Install();

--- a/src/hud/InjectHUD.cpp
+++ b/src/hud/InjectHUD.cpp
@@ -86,7 +86,6 @@ namespace {
             return;
         }
 
-        spdlog::info("[ERF HUD] FollowPlayerFixed");
         RE::GRectF rect = w._view->GetVisibleFrameRect();
         const double targetX = rect.left + InjectHUD::ERFWidget::kPlayerMarginLeftPx +
                                ERF::GetConfig().playerXPosition.load(std::memory_order_relaxed);

--- a/src/overrides/Overrides.cpp
+++ b/src/overrides/Overrides.cpp
@@ -1,0 +1,189 @@
+#include "Overrides.h"
+
+#include <RE/B/BGSKeyword.h>
+#include <RE/B/BGSKeywordForm.h>
+#include <RE/E/Effect.h>
+#include <RE/E/EffectSetting.h>
+#include <RE/S/SpellItem.h>
+
+#include <algorithm>
+#include <cmath>
+
+#include "RE/T/TESForm.h"
+
+bool SpellKey::operator==(const SpellKey& o) const noexcept {
+    return formID == o.formID && _stricmp(plugin.c_str(), o.plugin.c_str()) == 0;
+}
+size_t SpellKeyHash::operator()(const SpellKey& k) const noexcept {
+    std::string p = k.plugin;
+    std::transform(p.begin(), p.end(), p.begin(), ::tolower);
+    return std::hash<uint32_t>{}(k.formID) ^ (std::hash<std::string>{}(p) << 1);
+}
+
+const std::filesystem::path& ERF_GetThisDllDir();
+
+static RE::EffectSetting* s_mgefGauge = nullptr;
+static std::unordered_set<RE::BGSKeyword*> s_erfKeywords;
+
+bool ERF::Overrides::InitResources() { return (s_mgefGauge != nullptr); }
+
+void ERF::Overrides::SetGaugeEffect(RE::EffectSetting* mgef) { s_mgefGauge = mgef; }
+
+void ERF::Overrides::SetERFKeywords(std::unordered_set<RE::BGSKeyword*> kws) { s_erfKeywords = std::move(kws); }
+
+bool ERF::Overrides::HasERFKeyword(const RE::EffectSetting* mgef) {
+    if (!mgef) return false;
+    for (auto* kw : mgef->GetKeywords()) {
+        if (!kw) continue;
+        if (ElementRegistry::get().findByKeyword(kw).has_value()) return true;
+    }
+    return false;
+}
+
+RE::Effect* ERF::Overrides::FindGaugeEffect(RE::SpellItem* sp) {
+    if (!sp) return nullptr;
+
+    for (RE::Effect* ei : sp->effects) {
+        if (ei && ei->baseEffect == s_mgefGauge) {
+            return ei;
+        }
+    }
+    return nullptr;
+}
+
+void ERF::Overrides::EnsureGaugeEffect(RE::SpellItem* sp, float defaultMag) {
+    if (!sp || !s_mgefGauge) return;
+    if (FindGaugeEffect(sp)) return;
+
+    RE::Effect* eff = new RE::Effect();
+    eff->baseEffect = s_mgefGauge;
+    eff->effectItem.magnitude = defaultMag;
+    eff->effectItem.area = 0;
+    eff->effectItem.duration = 0;
+    eff->cost = 0;
+
+    sp->effects.push_back(eff);
+}
+
+void ERF::Overrides::SetGaugeMagnitude(RE::SpellItem* sp, float mag) {
+    if (RE::Effect* ei = FindGaugeEffect(sp)) {
+        if (std::fabs(ei->effectItem.magnitude - mag) > 1e-4f) {
+            ei->effectItem.magnitude = mag;
+        }
+    }
+}
+
+std::vector<RE::SpellItem*> ERF::Overrides::ScanAllSpellsWithKeyword() {
+    std::vector<RE::SpellItem*> out;
+
+    auto* dh = RE::TESDataHandler::GetSingleton();
+    auto& arr = dh->GetFormArray<RE::SpellItem>();
+
+    auto getLoadOrderIndex = [&](const RE::TESFile* f) -> int {
+        if (!f) return -1;
+        int idx = 0;
+        for (auto* file : dh->files) {
+            if (file == f) return idx;
+            ++idx;
+        }
+        return -1;
+    };
+
+    std::unordered_map<std::uint32_t, RE::SpellItem*> best;
+    best.reserve(arr.size() / 3 + 16);
+
+    auto keep = [&](RE::SpellItem* sp) {
+        std::uint32_t key = sp->formID & 0x00FFFFFF;
+        const int lo = getLoadOrderIndex(sp->GetDescriptionOwnerFile());
+
+        auto it = best.find(key);
+        if (it == best.end()) {
+            best.emplace(key, sp);
+        } else {
+            RE::SpellItem* cur = it->second;
+            const int loCur = getLoadOrderIndex(cur->GetDescriptionOwnerFile());
+            if (lo > loCur) {
+                it->second = sp;
+            }
+        }
+    };
+
+    for (auto* sp : arr) {
+        if (!sp || sp->effects.empty()) continue;
+
+        bool eligible = false;
+        for (auto& ei : sp->effects) {
+            if (ei && HasERFKeyword(ei->baseEffect)) {
+                eligible = true;
+                break;
+            }
+        }
+
+        if (eligible) {
+            keep(sp);
+        }
+    }
+
+    out.reserve(best.size());
+    for (auto& [key, sp] : best) {
+        out.push_back(sp);
+    }
+    return out;
+}
+
+std::string ERF::Overrides::GetEditorID(const RE::TESForm* f) {
+    if (!f) return {};
+    if (const char* ed = f->GetFormEditorID(); ed && ed[0]) return ed;
+    return {};
+}
+
+std::string ERF::Overrides::GetDisplayName(const RE::TESForm* f) {
+    if (!f) return {};
+
+    const char* name = f->GetName();
+    return name ? std::string(name) : std::string();
+}
+
+std::string ERF::Overrides::FormIDHex(std::uint32_t id) {
+    char buf[9];
+    std::snprintf(buf, sizeof(buf), "%08X", id);
+    return buf;
+}
+
+static std::filesystem::path ComputeOverridesPath() {
+    const auto& dllDir = ERF_GetThisDllDir();
+    if (!dllDir.empty()) {
+        return dllDir / "ERF" / "spell_overrides.json";
+    }
+
+    if (auto logDirOpt = SKSE::log::log_directory()) {
+        return *logDirOpt / "ERF" / "spell_overrides.json";
+    }
+
+    return std::filesystem::path("Data") / "SKSE" / "Plugins" / "ERF" / "spell_overrides.json";
+}
+
+const std::filesystem::path& ERF::Overrides::OverridesPath() {
+    static const std::filesystem::path kCached = ComputeOverridesPath();
+    return kCached;
+}
+
+bool ERF::Overrides::EnsureOverridesFolder() {
+    std::error_code ec;
+    const auto dir = OverridesPath().parent_path();
+    if (dir.empty()) return false;
+    return std::filesystem::exists(dir) || std::filesystem::create_directories(dir, ec);
+}
+
+std::string_view ERF::Overrides::OwningPlugin(const RE::TESForm* f) {
+    if (!f) return {};
+    if (auto* file = f->GetDescriptionOwnerFile()) {
+        if (std::string_view name = file->GetFilename(); !name.empty()) return name;
+    }
+    return {};
+}
+
+std::uint32_t ERF::Overrides::RawFormID(const RE::TESForm* f) {
+    if (!f) return 0;
+    return f->formID;
+}

--- a/src/overrides/Overrides.h
+++ b/src/overrides/Overrides.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "RE/Skyrim.h"
+
+struct SpellKey {
+    std::string plugin;
+    std::uint32_t formID{};
+    bool operator==(const SpellKey& o) const noexcept;
+};
+struct SpellKeyHash {
+    size_t operator()(const SpellKey& k) const noexcept;
+};
+
+namespace ERF::Overrides {
+
+    const std::filesystem::path& OverridesPath();
+    bool EnsureOverridesFolder();
+
+    bool InitResources();
+
+    void SetGaugeEffect(RE::EffectSetting* mgef);
+    void SetERFKeywords(std::unordered_set<RE::BGSKeyword*> kws);
+
+    bool HasERFKeyword(const RE::EffectSetting* mgef);
+    RE::Effect* FindGaugeEffect(RE::SpellItem* sp);
+
+    void EnsureGaugeEffect(RE::SpellItem* sp, float defaultMag);
+    void SetGaugeMagnitude(RE::SpellItem* sp, float mag);
+
+    std::vector<RE::SpellItem*> ScanAllSpellsWithKeyword();
+
+    std::string GetEditorID(const RE::TESForm* f);
+    std::string GetDisplayName(const RE::TESForm* f);
+    std::string FormIDHex(std::uint32_t id);
+    std::string_view OwningPlugin(const RE::TESForm* f);
+    std::uint32_t RawFormID(const RE::TESForm* f);
+}

--- a/src/teste.cpp
+++ b/src/teste.cpp
@@ -28,12 +28,8 @@ static ERF_API_V1* AcquireERF() {
 
     g_erf = ERF_GetAPI(ERF_API_VERSION);  // v1 estendida
     if (!g_erf) {
-        spdlog::warn("[ERF-Test] ERF API v{} ainda não disponível", ERF_API_VERSION);
         return nullptr;
     }
-    spdlog::info("[ERF-Test] ERF API v{} adquirida (open={}, frozen={})", g_erf->version,
-                 g_erf->IsRegistrationOpen ? g_erf->IsRegistrationOpen() : -1,
-                 g_erf->IsFrozen ? g_erf->IsFrozen() : -1);
     return g_erf;
 }
 
@@ -96,8 +92,6 @@ static void RegisterEverything_Core() {
         shock = api->RegisterElement(d);
     }
 
-    spdlog::info("[ERF-Test] Elements -> Fire={} Frost={} Shock={}", fire, frost, shock);
-
     // 2) Estados
     ERF_StateHandle wet{}, rubber{}, fur{};
     {
@@ -112,7 +106,6 @@ static void RegisterEverything_Core() {
         ERF_StateDesc_Public s{"Fur", 0};
         fur = api->RegisterState(s);
     }
-    spdlog::info("[ERF-Test] States -> Wet={} Rubber={} Fur={}", wet, rubber, fur);
 
     // 3) Multiplicadores estado×elemento
     api->SetElementStateMultiplier(fire, wet, 0.10);
@@ -145,7 +138,6 @@ static void RegisterEverything_Core() {
         p.user = nullptr;
 
         auto ph = api->RegisterPreEffect(p);
-        spdlog::info("[ERF-Test] PreEffect '{}' -> {}", p.name, ph);
     }
 
     // 5) Reação simples: Solo Fire 85% (callback de log)
@@ -172,10 +164,7 @@ static void RegisterEverything_Core() {
         r.user = nullptr;
 
         auto rh = api->RegisterReaction(r);
-        spdlog::info("[ERF-Test] Reaction '{}' -> {}", r.name, rh);
     }
-
-    spdlog::info("[ERF-Test] Registro concluído.");
 }
 
 // Envolve o registro com a JANELA/BARREIRA
@@ -196,15 +185,12 @@ static void RegisterEverything_WithWindow() {
         // Tente pelo menos logar o estado pra diagnosticar.
         const int open = api->IsRegistrationOpen ? (api->IsRegistrationOpen() ? 1 : 0) : -1;
         const int froz = api->IsFrozen ? (api->IsFrozen() ? 1 : 0) : -1;
-        spdlog::warn("[ERF-Test] BeginBatchRegistration falhou (open={}, frozen={}) — tentando registrar assim mesmo.",
-                     open, froz);
     }
 
     RegisterEverything_Core();
 
     if (usedBarrier && api->EndBatchRegistration) {
         api->EndBatchRegistration();
-        spdlog::info("[ERF-Test] EndBatchRegistration chamado.");
 
 #if FORCE_FREEZE_AFTER_END
         if (api->FreezeNow) {
@@ -232,7 +218,6 @@ static void OnSKSEMessage(SKSE::MessagingInterface::Message* msg) {
 extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* skse) {
     SKSE::Init(skse);
     spdlog::set_level(spdlog::level::info);
-    spdlog::info("[ERF-Test] SKSEPlugin_Load");
 
     if (auto* m = SKSE::GetMessagingInterface()) {
         m->RegisterListener(OnSKSEMessage);  // só eventos SKSE; nada de “canal” da ERF

--- a/src/ui/ERF_UI.h
+++ b/src/ui/ERF_UI.h
@@ -5,5 +5,6 @@
 namespace ERF_UI {
     void __stdcall DrawGeneral();
     void __stdcall DrawHUD();
+    void __stdcall DrawEditGauge();
     void Register();
 }


### PR DESCRIPTION
adicionei no SKSE menu uma nova aba que lista as todas as spells com keywords registradas e permite editar a magnitude de gauge, ou seja, quantos pontos de gauge aquela spell aplica. Além disso é possível salvar essa configuração para um json. Removido alguns comentários do código

Há um bug na busca do editorID que esta falhando em retornar o editorID

## Summary by Sourcery

Add an “Edit Gauges” tab to the SKSE menu for listing all ERF-keyworded spells, editing per-spell gauge magnitudes in-game, and saving overrides to a JSON file. Back this with a new Overrides module that scans spells with ERF keywords, ensures a gauge effect is present, manages get/set magnitude operations, and computes file paths using the plugin’s DLL directory. Remove obsolete logging and unused keyword logic, update configuration path resolution, and integrate the new module into CMake.

New Features:
- Add “Edit Gauges” UI tab with spell filtering, magnitude editing, and JSON save functionality
- Introduce Overrides subsystem to scan ERF-keyworded spells, apply and manage gauge effects, and serialize overrides

Enhancements:
- Resolve config and override file paths relative to the plugin DLL directory
- Clean up obsolete gauge keyword lookup and remove excess logging

Chores:
- Update CMakeLists to include the Overrides module and define SKSE support flags