### PR TITLE
feat(gauges): :sparkles: carregar valor de gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,52 @@
-# Skyrim Magic System Overhaul: Destruction
+# Elemental Reactions Framework (ERF)
 
-**Skyrim Magic System Overhaul: Destruction** is a comprehensive mod for *The Elder Scrolls V: Skyrim Special Edition* that redefines the Destruction school with a dynamic elemental system. Built using SKSE and C++ for top-tier performance, this mod introduces gauge-based mechanics, elemental states, powerful reactions, and 39 reworked spells to make fire, frost, and shock magic strategic and immersive. From incinerating foes with explosive combos to freezing enemies solid or chaining lightning through crowds, SMSO Des transforms magical combat into a spectacle of elemental mastery.
+**Elemental Reactions Framework (ERF)** is a high-performance SKSE/C++ **framework** for Skyrim SE/AE that lets mods **register Elements, States, Pre-Effects, and Reactions**, and drive a **gauge system** that accumulates on actors and **triggers reactions at 100**. It also ships an in-game HUD and an SKSE-Menu configuration UI.
 
-## Features
+---
 
-### 1. Elemental Gauges
+## What ERF is (in one paragraph)
 
-Every Destruction spell (fire, frost, shock) builds a corresponding gauge (*FireGauge*, *FrostGauge*, *ShockGauge*) on enemies when hit. Gauges track elemental exposure, enabling powerful effects and reactions when filled to 100 units.
+ERF provides a lightweight runtime for **elemental gameplay**. Mods declare **Elements** (e.g., Fire, Frost, Shock), optional **States** (e.g., Wet), **Pre-Effects** (logic that runs before a reaction), and **Reactions** (logic that executes when thresholds are met). During combat, ERF tracks **per-actor gauges** for each registered element and fires the best matching reaction when the **threshold (100)** is reached — either **Single** (per-element) or **Mixed** (combined share across elements).
 
-### 2. Elemental States
+---
 
-Environmental and equipment-based states alter how enemies interact with magic:
+## Key Concepts
 
-- **Wet**: Triggered by rain or water effects. Reduces fire damage and *FireGauge* buildup, but boosts shock damage and *frostGauge*.
-- **Rubber**: From crafted rubber armor. Reduces shock damage and *ShockGauge* buildup, but ncreases the buildup rate of FireGauge and FrostGauge.
-- **Fur/Fat**: From crafted fur armor or enemies like trolls. Enhances frost resistance and *FrostGauge* buildup, but increases fire damage taken and speeds up ShockGauge buildup
+### Elements
+- Each Element has a **name**, a **color (RGB)** for HUD, and a **keyword/MGEF linkage** to detect accumulation from spells or effects.
 
-### 3. Maximum Gauge Effects
+### States
+- Long/short-lived flags on actors that can **modify gauge gain** or **reaction selection** (e.g., *Wet* boosts Shock gauge, reduces Fire, etc.).
 
-When a gauge reaches 100 units, a unique effect triggers:
+### Pre-Effects
+- Callbacks executed **when accumulation happens** (before evaluating reactions).
+- Useful for micro-interactions, e.g. “spark” visuals, small slowdowns, or conditional locks.
 
-- **Incineration (Fire)**: A damage-over-time (DoT) effect burns the target.
-- **Deep Freeze (Frost)**: Freezes the target for 3 seconds, immobilizing them with a lingering slow effect.
-- **Overcharge (Shock)**: Cause small continuous electric shocks that stagger the enemy for 0.3 seconds every 1.3 seconds. Enemies with the 'electrified' effect shock nearby enemies also affected by electricity.
+### Reactions
+- Declared with an **element signature** (single or multi-element), **threshold policy** and **callback**.
+- **Mixed mode**: ERF computes the **share** of each element in the gauge sum (0–100) and picks the best matching reaction for the current composition.
+- **Single mode**: reaction triggers when an **individual element** hits 100.
 
-### 4. Elemental Reactions
+---
 
-Combining elements triggers powerful reactions by consuming one gauge to amplify another:
+## HUD & Configuration (SKSE Menu)
 
-### 5. Removal of Vanilla Drains
+- Built-in circular **gauge HUD** per actor (player/NPC) with:
+  - **Layout**: horizontal or vertical alignment, adjustable spacing.
+  - **Offsets**: per-actor-type X/Y offsets (player & NPC).
+  - **Scale**: per-actor-type scaling.
+  - **Modes**: toggle HUD on/off; toggle Single vs Mixed.
+  - **Multipliers**: separate gauge gain multipliers for player/NPC.
+- All settings persist to an **INI** next to the DLL and can be changed in-game via the **SKSE Menu** (no SkyUI/MCM dependency required).
 
-Vanilla magicka and stamina drains from shock and frost spells are removed, replaced by the gauge system for a cohesive experience.
+---
 
-### 6. Reworked Spells (39 New Spells)
-
-The Destruction school is revamped with 39 spells (11 fire, 11 frost, 11 shock), from Novice to Master:
-
-### 7. Reworked Perks
-
-The Destruction perk tree is overhauled:
-
-### 8. Power-Ups for Low-Level Spells
-
-Novice to Adept spells scale with Destruction skill.
-
-### 9. Cooldowns for Balance
-
-Spells have cooldowns.
-
-### 10. Long-Cast Animations and NPC Collaboration
-
-Higher-ranked spells have longer animations. Spells will continuously drain mana during the animation until their cost is met. It is possible for one (or more) NPC with the same spell to cast simultaneously, jointly consuming mana until the total required for activating the spell is reached. If this is done, only one spell will be cast, but the casting time can be drastically reduced. The initial mana points are consumed more rapidly, but subsequent points are consumed more slowly.
 
 ## Contributing
 
-Want to contribute to *SMSOD*? We welcome bug fixes, feature suggestions, and code contributions!
+Want to contribute to *ERF*? We welcome bug fixes, feature suggestions, and code contributions!
 
-1. Fork the repository on [GitHub](https://github.com/IgorAlanAlbuquerque/SMSO---Destruction/tree/main).
+1. Fork the repository on [GitHub](https://github.com/IgorAlanAlbuquerque/Elemental-Reactions-Framework).
 2. Create a branch for your changes (`git checkout -b feature/your-feature`).
 3. Commit your changes with clear messages (`git commit -m "Add feature X"`).
 4. Push to your fork (`git push origin feature/your-feature`).

--- a/src/elemental_reactions/ElementalGaugesHook.cpp
+++ b/src/elemental_reactions/ElementalGaugesHook.cpp
@@ -21,6 +21,8 @@
 
 using namespace std::chrono;
 
+RE::EffectSetting* ElementalGaugesHook::g_mgefGaugeAcc = nullptr;
+
 namespace {
     template <class K, class V, std::size_t N = 64>
     struct StripedMap {

--- a/src/elemental_reactions/ElementalGaugesHook.h
+++ b/src/elemental_reactions/ElementalGaugesHook.h
@@ -7,7 +7,7 @@
 
 namespace ElementalGaugesHook {
     extern std::atomic_bool ALLOW_HUD_TICK;
-    static RE::EffectSetting* g_mgefGaugeAcc = nullptr;
+    extern RE::EffectSetting* g_mgefGaugeAcc;
     void StartHUDTick();
     void StopHUDTick();
     void Install();

--- a/src/overrides/Overrides.h
+++ b/src/overrides/Overrides.h
@@ -26,7 +26,6 @@ namespace ERF::Overrides {
     bool InitResources();
 
     void SetGaugeEffect(RE::EffectSetting* mgef);
-    void SetERFKeywords(std::unordered_set<RE::BGSKeyword*> kws);
 
     bool HasERFKeyword(const RE::EffectSetting* mgef);
     RE::Effect* FindGaugeEffect(RE::SpellItem* sp);
@@ -41,4 +40,5 @@ namespace ERF::Overrides {
     std::string FormIDHex(std::uint32_t id);
     std::string_view OwningPlugin(const RE::TESForm* f);
     std::uint32_t RawFormID(const RE::TESForm* f);
+    std::size_t ApplyOverridesFromJSON();
 }

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -81,6 +81,7 @@ namespace {
                 ERF::GetConfig().Load();
                 ERF_UI::Register();
                 ERF::Overrides::SetGaugeEffect(ElementalGaugesHook::g_mgefGaugeAcc);
+                ERF::Overrides::ApplyOverridesFromJSON();
                 break;
             }
 

--- a/src/ui/ERF_UI.cpp
+++ b/src/ui/ERF_UI.cpp
@@ -293,8 +293,8 @@ void __stdcall ERF_UI::DrawEditGauge() {
     if (ImGui::BeginTable("##erf_spells", 3,
                           ImGuiTableFlags_Resizable | ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
         ImGui::TableSetupColumn("EditorID", ImGuiTableColumnFlags_WidthStretch);
-        ImGui::TableSetupColumn("Plugin", ImGuiTableColumnFlags_WidthFixed, 180.0f);
-        ImGui::TableSetupColumn("Magnitude", ImGuiTableColumnFlags_WidthFixed, 120.0f);
+        ImGui::TableSetupColumn("Plugin", ImGuiTableColumnFlags_WidthFixed, 200.0f);
+        ImGui::TableSetupColumn("Magnitude", ImGuiTableColumnFlags_WidthFixed, 200.0f);
         ImGui::TableHeadersRow();
 
         for (auto& r : rows) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,5 +2,5 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "elemental-reactions-framework",
   "version-string": "0.0.1",
-  "dependencies": ["commonlibsse-ng", "simpleini"]
+  "dependencies": ["commonlibsse-ng", "simpleini", "nlohmann-json"]
 }


### PR DESCRIPTION
agora ele carrega os valores dos gauges de um json ao iniciar. Isso permite alterar facilmente a magnitude do quanto de gauge é aplicado por cada spell. Além disso, ele automaticamente aplica um patch adicionando o magic effect de acumulador a spells que tenham keyword de elemento registrado, mas não tenham o magic effect especifico adicionado.

## Summary by Sourcery

Load and apply spell gauge values from a JSON configuration and auto-add missing gauge effects to elemental spells, supported by new helper functions and JSON-override logic; update UI column layouts and rebrand documentation to reflect the ERF framework.

New Features:
- Load gauge magnitudes for spells from a JSON file at initialization
- Automatically patch spells with registered element keywords by adding a gauge accumulator effect when missing

Enhancements:
- Implement helper to locate spells by plugin and base form ID
- Introduce ApplyOverridesFromJSON to parse and apply gauge overrides from JSON during plugin startup
- Refactor g_mgefGaugeAcc symbol linkage and remove unused SetERFKeywords API

Documentation:
- Revise README to rebrand from SMSO Destruction to the Elemental Reactions Framework and outline key framework features