### PR TITLE
perf: :zap: Chamada de StartHUDTick dentro do add de gauges e no ativ…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,6 @@ add_commonlibsse_plugin(ElementalReactionsFramework
     src/overrides/Overrides.cpp
 )
 
-target_compile_definitions(ElementalReactionsFramework PRIVATE
-  SKYRIM_SUPPORT_AE
-  SKYRIM_SUPPORT_SE
-)
-
 target_include_directories(ElementalReactionsFramework
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/src/elemental_reactions/ElementalGauges.cpp
+++ b/src/elemental_reactions/ElementalGauges.cpp
@@ -17,6 +17,7 @@
 #include "../Config.h"
 #include "../common/Helpers.h"
 #include "../common/PluginSerialization.h"
+#include "../hud/HUDTick.h"
 #include "../hud/InjectHUD.h"
 #include "ElementalStates.h"
 #include "erf_preeffect.h"
@@ -701,6 +702,8 @@ void ElementalGauges::Add(RE::Actor* a, ERF_ElementHandle elem, int delta) {
     e.lastHitH[i] = nowH;
     e.lastEvalH[i] = nowH;
     onValChange(e, i, before, afterI);
+
+    HUD::StartHUDTick();
 
     if (const bool singleMode = ERF::GetConfig().isSingle.load(std::memory_order_relaxed); singleMode) {
         // SINGLE

--- a/src/hud/InjectHUD.cpp
+++ b/src/hud/InjectHUD.cpp
@@ -10,6 +10,7 @@
 
 #include "../Config.h"
 #include "../elemental_reactions/ElementalGauges.h"
+#include "HUDTick.h"
 #include "Offsets.h"
 #include "Utils.h"
 
@@ -444,10 +445,10 @@ void InjectHUD::BeginReaction(RE::Actor* a, ERF_ReactionHandle handle, float sec
     pr.secs = seconds;
     pr.realTime = realTime;
 
-    {
-        std::scoped_lock lk(g_comboMx);
-        g_comboQueue.push_back(std::move(pr));
-    }
+    std::scoped_lock lk(g_comboMx);
+    g_comboQueue.push_back(std::move(pr));
+
+    HUD::StartHUDTick();
 }
 
 bool InjectHUD::HideFor(RE::FormID id) {


### PR DESCRIPTION
…ar reação do injectHUD. Diminui o delay da hud aparecer após uma mudança no gauge.

## Summary by Sourcery

Start the HUD update tick immediately upon gauge changes and reaction queuing to reduce HUD display delay, and remove obsolete compile definitions from the build configuration.

Enhancements:
- Call HUD::StartHUDTick after queuing reaction events in InjectHUD to trigger HUD updates promptly
- Call HUD::StartHUDTick after gauge value changes in ElementalGauges to immediately refresh the HUD

Build:
- Remove SKYRIM_SUPPORT_AE and SKYRIM_SUPPORT_SE compile definitions from CMakeLists