### PR TITLE
perf(Guages): :zap: Substituição de atribuições por try_emplace

### DIFF
--- a/src/elemental_reactions/ElementalGauges.cpp
+++ b/src/elemental_reactions/ElementalGauges.cpp
@@ -699,8 +699,10 @@ namespace {
 void ElementalGauges::Add(RE::Actor* a, ERF_ElementHandle elem, int delta) {
     if (!a || delta <= 0) return;
 
-    auto& e = Gauges::state()[a->GetFormID()];
-    Gauges::initEntryDenseIfNeeded(e);
+    auto& M = Gauges::state();
+    auto [__it, __inserted] = M.try_emplace(a->GetFormID());
+    auto& e = __it->second;
+    if (__inserted) Gauges::initEntryDenseIfNeeded(e);
 
     const auto i = Gauges::idx(elem);
     const float nowH = NowHours();
@@ -763,8 +765,10 @@ std::uint8_t ElementalGauges::Get(RE::Actor* a, ERF_ElementHandle elem) {
 void ElementalGauges::Set(RE::Actor* a, ERF_ElementHandle elem, std::uint8_t value) {
     if (!a || elem == 0) return;
 
-    auto& e = Gauges::state()[a->GetFormID()];
-    Gauges::initEntryDenseIfNeeded(e);
+    auto& M = Gauges::state();
+    auto [__it, __inserted] = M.try_emplace(a->GetFormID());
+    auto& e = __it->second;
+    if (__inserted) Gauges::initEntryDenseIfNeeded(e);
 
     const std::size_t i = Gauges::idx(elem);
     const float nowH = NowHours();

--- a/src/elemental_reactions/erf_reaction.cpp
+++ b/src/elemental_reactions/erf_reaction.cpp
@@ -73,7 +73,8 @@ void ReactionRegistry::buildIndex_() const {
         _minPctEachByH[h] = r.minPctEach;
         _minSumSelByH[h] = r.minSumSelected;
 
-        auto& bucket = _byMask[m];
+        auto [__itB, __insertedB] = _byMask.try_emplace(m);
+        auto& bucket = __itB->second;
         if (bucket.empty()) bucket.reserve(4);
         bucket.push_back(h);
     }

--- a/src/hud/HUDTick.cpp
+++ b/src/hud/HUDTick.cpp
@@ -59,7 +59,8 @@ namespace {
             if (!a) {
                 a = RE::TESForm::LookupByID<RE::Actor>(id);
                 if (a) {
-                    auto& entry = InjectHUD::widgets[id];
+                    auto [__itW, __insertedW] = InjectHUD::widgets.try_emplace(id);
+                    auto& entry = __itW->second;
                     entry.handle = a->CreateRefHandle();
                 }
             }


### PR DESCRIPTION
–1 hash/lookup por upsert operator[] faz lookup e pode construir o valor default; try_emplace faz um lookup e só constrói se precisar. Em rotas como Add/Set (gauges) isso corta custo em toda ativação.  Menos alocações e zero construções inúteis Sem criar temporários nem valores default que serão sobrescritos em seguida. Isso reduz churn do alocador e pressão de cache.  Menos contenção/rehash sob carga Em lutas com muitos eventos/segundo, cada economia de lookup+alocação reduz a chance de rehash e os spikes de tempo de quadro.

## Summary by Sourcery

Replace unordered_map operator[] with try_emplace to reduce redundant lookups and default constructions for gauges and HUD widgets, improving performance under load; modernize code by using C++17 if-with-init statements and auto for pointer declarations.

Enhancements:
- Substitute map operator[] upserts with try_emplace in multiple containers to cut hash lookups, unnecessary allocations, and default constructions
- Use C++17 if-with-init statements for inline declaration of temporaries in conditional logic
- Switch explicit pointer types in reinterpret_casts to auto to streamline code style