### PR TITLE
perf(Memory): :zap: Evitar alocações por frame

### DIFF
--- a/src/elemental_reactions/ElementalGauges.cpp
+++ b/src/elemental_reactions/ElementalGauges.cpp
@@ -688,7 +688,8 @@ namespace {
 
             Gauges::rebuildPresence(e);
 
-            m[newID] = std::move(e);
+            auto [it, ins] = m.try_emplace(newID, std::move(e));
+            if (!ins) it->second = std::move(e);
         }
         return true;
     }


### PR DESCRIPTION
Zero alocações por frame para os arrays do HUD (remain/tints/accum/cores + lista de reações).  Menos churn do alocador e menos fragmentação, o que estabiliza o tempo do thread de UI (Scaleform).  Queda de spikes em combates com muitos eventos/segundo (efeito direto em micro-stutter).  Menos cópias (o GetActiveReactions não cria vetor temporário nem retorna por valor).  Capacidade sob demanda: só aumenta reserve quando aparece um pacote maior que o usual (mantendo o “steady-state” barato).

## Summary by Sourcery

Eliminate per-frame heap allocations in HUD rendering by reusing thread-local buffers and streamline reaction collection, and optimize map insertion in ElementalGauges.

Enhancements:
- Introduce thread_local HUDTLS with reserved containers to reuse HUD arrays across frames and reduce allocator churn and fragmentation
- Refactor GetActiveReactions to clear and populate a provided output vector in-place with capacity growth only when necessary
- Replace local per-frame std::vector allocations for comboRemain01, comboTintsRGB, accumValues, accumColorsRGB, and actives with thread-local storage reuse
- Use try_emplace with conditional assignment in ElementalGauges to avoid redundant moves during map insertion