### PR TITLE
fix(HUD): :bug: Corrigido bug em que os widgets não eram limpos após …

### DIFF
--- a/src/hud/HUDTick.cpp
+++ b/src/hud/HUDTick.cpp
@@ -39,6 +39,12 @@ namespace {
         const float nowH = RE::Calendar::GetSingleton()->GetHoursPassed();
         InjectHUD::OnUIFrameBegin(nowRt, nowH);
 
+        if (auto* pc = RE::PlayerCharacter::GetSingleton(); pc && pc->IsDead()) {
+            InjectHUD::RemoveAllWidgets();
+            HUD::ResetTracking();
+            return;
+        }
+
         const float now = RE::Calendar::GetSingleton()->GetCurrentGameTime() * 3600.0f;
 
         constexpr float ZERO_GRACE_SECONDS = 0.1f;

--- a/src/hud/InjectHUD.cpp
+++ b/src/hud/InjectHUD.cpp
@@ -622,6 +622,7 @@ void InjectHUD::OnTrueHUDClose() {
     RemoveAllWidgets();
     Utils::HeadCacheClearAll();
     HUD::ResetTracking();
+    HUD::StopHUDTick();
 }
 
 void InjectHUD::OnUIFrameBegin(double nowRtS, float nowH) {

--- a/src/hud/TrueHUDMenuWatcher.cpp
+++ b/src/hud/TrueHUDMenuWatcher.cpp
@@ -6,7 +6,7 @@ using TrueHUDWatcher::TrueHUDMenuWatcher;
 
 RE::BSEventNotifyControl TrueHUDMenuWatcher::ProcessEvent(const RE::MenuOpenCloseEvent* ev,
                                                           RE::BSTEventSource<RE::MenuOpenCloseEvent>*) {
-    if (!ev || !ev->menuName.empty()) {
+    if (!ev || ev->menuName.empty()) {
         return RE::BSEventNotifyControl::kContinue;
     }
 


### PR DESCRIPTION
…morrer

O erro acontecia devido a uma condição invertida no if de trueHUDMenuWatcher

## Summary by Sourcery

Ensure HUD widgets are properly removed and HUD tick is stopped on player death or TrueHUD closure, and correct menu watcher logic to resume HUD updates only when appropriate.

Bug Fixes:
- Clear all HUD widgets and reset tracking immediately upon player death
- Correct inverted condition in TrueHUDMenuWatcher to skip only empty menu events
- Stop the HUD tick when TrueHUD is closed to prevent lingering updates