### PR TITLE
feat(API): :sparkles: corrigido funcionamento de ordered e atualizado…

### DIFF
--- a/src/ElementalReactionsAPI.h
+++ b/src/ElementalReactionsAPI.h
@@ -13,106 +13,166 @@ namespace RE {
     class Actor;
 }
 
-// ===================== Versão da interface =====================
+// ===================== API version =====================
+// Bumped whenever the public interface changes in a breaking way.
 inline constexpr std::uint32_t ERF_API_VERSION = 2;
 
-// ===================== Handles públicos =====================
+// ===================== Public handles =====================
+// Opaque numeric handles returned by the registration functions.
+// They are stable for the lifetime of the game session and should
+// be stored by the consumer instead of keeping raw pointers.
 using ERF_ElementHandle = std::uint16_t;
 using ERF_StateHandle = std::uint16_t;
 using ERF_ReactionHandle = std::uint16_t;
 using ERF_PreEffectHandle = std::uint16_t;
 
-// ===================== Tipos auxiliares públicos =====================
+// ===================== Public helper types =====================
+
+// Context passed to a reaction callback.
+// Currently only exposes the target Actor, but can be extended
+// in future API versions while remaining binary-compatible.
 struct ERF_ReactionContext {
     RE::Actor* target;
 };
 
+// Callback type for reactions triggered when gauge conditions are met.
+// `user` is the same pointer passed in the reaction descriptor at registration time.
 using ERF_ReactionCallback = void (*)(const ERF_ReactionContext& ctx, void* user);
+
+// Callback type for per-element pre-effects that are evaluated continuously
+// while the gauge is above a minimum threshold.
+// `gauge` is in [0, 100], `intensity` is computed from the descriptor fields.
+// `user` is the same pointer passed in the pre-effect descriptor.
 using ERF_PreEffectCallback = void (*)(RE::Actor* actor, ERF_ElementHandle element, std::uint8_t gauge, float intensity,
                                        void* user);
 
-// ===================== Descritores públicos =====================
-// 1) Elemento
+// ===================== Public descriptors =====================
+//
+// These structs describe what you want to register in the framework.
+// They are copied by the implementation, so pointers only need to
+// remain valid during the registration call.
+
+// 1) Element
+// Defines a single elemental type (e.g. "fire", "frost") that can
+// accumulate gauge on actors and participate in reactions.
 struct ERF_ElementDesc_Public {
-    const char* name;
-    std::uint32_t colorRGB;   // 0xRRGGBB
-    std::uint32_t keywordID;  // FormID (0 se não usar)
-    bool noMixInMixedMode;
+    const char* name;         // Unique name for this element (ASCII, null-terminated).
+    std::uint32_t colorRGB;   // UI color in 0xRRGGBB format.
+    std::uint32_t keywordID;  // FormID of a BGSKeyword used to detect this element on magic effects (0 if unused).
+    bool noMixInMixedMode;    // If true, this element is ignored in mixed-mode gauge sums.
 };
 
-// 2) Reação (disparo em 100%)
+// 2) Reaction (triggered when gauge reaches configuration thresholds)
+// Describes a reaction that fires when the combined gauges of the
+// specified elements meet the percentage conditions.
 struct ERF_ReactionDesc_Public {
-    const char* name;
-    const ERF_ElementHandle* elements;
-    std::uint32_t elementCount;
-    bool ordered;
-    float minPctEach;
-    float minSumSelected;
-    float cooldownSeconds;
-    bool cooldownIsRealTime;
-    float elementLockoutSeconds;
-    bool elementLockoutIsRealTime;
-    bool clearAllOnTrigger;
-    std::uint32_t hudTint;
-    ERF_ReactionCallback cb;
-    void* user;
-    const char* iconName;
+    const char* name;                   // Unique name for this reaction (for debugging/logging).
+    const ERF_ElementHandle* elements;  // Array of element handles that must participate.
+    std::uint32_t elementCount;         // Number of entries in `elements`.
+
+    bool ordered;          // If true, the first element in `elements` must be the dominant one in the mixture.
+    float minPctEach;      // Minimum fraction (0–1) for each participating element relative to the total mix.
+    float minSumSelected;  // Minimum total fraction (0–1) of the selected elements relative to overall gauge.
+
+    float cooldownSeconds;        // Reaction-level cooldown duration.
+    float elementLockoutSeconds;  // Per-element lockout duration applied when this reaction triggers.
+
+    std::uint32_t hudTint;    // Optional UI tint for the HUD when this reaction triggers (0xRRGGBB).
+    ERF_ReactionCallback cb;  // Callback to run when this reaction is triggered.
+    void* user;               // User data pointer passed back to `cb` unchanged.
+    const char* iconName;     // Name of the HUD icon to use for this reaction (may be nullptr/empty).
 };
 
-// 3) Pré-efeito (contínuo por elemento)
+// 3) Pre-effect (continuous effect per element)
+// Describes a continuous effect tied to a single element and actor,
+// evaluated as long as the element gauge is above `minGauge`.
 struct ERF_PreEffectDesc_Public {
-    const char* name;
-    ERF_ElementHandle element;
-    std::uint8_t minGauge;
-    float baseIntensity, scalePerPoint, minIntensity, maxIntensity;
-    float durationSeconds;
-    bool durationIsRealTime;
-    float cooldownSeconds;
-    bool cooldownIsRealTime;
-    ERF_PreEffectCallback cb;
-    void* user;
+    const char* name;           // Unique name for this pre-effect (for debugging/logging).
+    ERF_ElementHandle element;  // Element this pre-effect is bound to.
+
+    std::uint8_t minGauge;  // Minimum gauge [0–100] required for this pre-effect to apply.
+
+    // Intensity curve parameters:
+    // intensity = clamp(baseIntensity + scalePerPoint * gauge,
+    //                   minIntensity, maxIntensity)
+    float baseIntensity;
+    float scalePerPoint;
+    float minIntensity;
+    float maxIntensity;
+
+    // Duration and cooldown settings for the effect instance.
+    float durationSeconds;    // How long the effect should last once triggered.
+    bool durationIsRealTime;  // If true, duration is in real-time seconds; otherwise game hours.
+    float cooldownSeconds;    // Cooldown before this pre-effect can trigger again on the same actor.
+    bool cooldownIsRealTime;  // If true, cooldown uses real-time seconds; otherwise game hours.
+
+    ERF_PreEffectCallback cb;  // Callback invoked when the pre-effect is (re)applied.
+    void* user;                // User data pointer passed back to `cb` unchanged.
 };
 
-// 4) Estado
+// 4) State
+// Describes a high-level state (e.g. "wet", "charged") that can
+// modify gauge gain and damage taken while active on an actor.
 struct ERF_StateDesc_Public {
-    const char* name;
-    std::uint32_t keywordID;
+    const char* name;         // Unique name for this state.
+    std::uint32_t keywordID;  // Optional keyword FormID that can be used by other systems (0 if unused).
 };
 
 // ===================== Interface V1 =====================
-struct ERF_API_V1 {
-    std::uint32_t version;  // ERF_API_VERSION
+//
+// Single flat vtable-style struct containing all public entry points.
+// Returned by RequestPluginAPI / ERF_GetAPI.
 
-    // 1) Registrar
+// Main API structure for version ERF_API_VERSION.
+struct ERF_API_V1 {
+    std::uint32_t version;  // Must be equal to ERF_API_VERSION.
+
+    // 1) Registration
+    // Called during the registration window (before Freeze) to declare
+    // elements, reactions, pre-effects and states.
     ERF_ElementHandle (*RegisterElement)(const ERF_ElementDesc_Public&);
     ERF_ReactionHandle (*RegisterReaction)(const ERF_ReactionDesc_Public&);
     ERF_PreEffectHandle (*RegisterPreEffect)(const ERF_PreEffectDesc_Public&);
     ERF_StateHandle (*RegisterState)(const ERF_StateDesc_Public&);
 
-    // 2) Multiplicadores
+    // 2) Multipliers
+    // Configure how each state modifies gauge accumulation and health
+    // damage for a given element.
+    //  - gaugeMult  > 1 increases gauge gain; < 1 reduces it.
+    //  - healthMult > 1 increases damage taken; < 1 reduces it.
     void (*SetElementStateMultiplier)(ERF_ElementHandle elem, ERF_StateHandle state, double gaugeMult,
                                       double healthMult);
 
-    // 3) Estados dinâmicos
+    // 3) Dynamic states
+    // Turn states on/off for a given actor at runtime.
     bool (*ActivateState)(RE::Actor*, ERF_StateHandle);
     bool (*DeactivateState)(RE::Actor*, ERF_StateHandle);
 
-    // 4) Janela / freeze
-    bool (*BeginBatchRegistration)();
-    void (*EndBatchRegistration)();
-    void (*SetFreezeTimeoutMs)(std::uint32_t);
-    bool (*IsRegistrationOpen)();
-    bool (*IsFrozen)();
-    void (*FreezeNow)();
+    // 4) Registration window / freeze control
+    // Used to group registration calls and control when the internal
+    // data structures become read-only for fast lookup.
+    bool (*BeginBatchRegistration)();           // Open registration window (returns false on failure).
+    void (*EndBatchRegistration)();             // Close registration window (no more changes allowed in this batch).
+    void (*SetFreezeTimeoutMs)(std::uint32_t);  // Safety timeout before auto-freezing the registry.
+    bool (*IsRegistrationOpen)();               // True while registration window is open.
+    bool (*IsFrozen)();                         // True after registries have been frozen.
+    void (*FreezeNow)();                        // Force an immediate freeze of all registries.
 };
 
-// ===================== Helper: resolver/cachesr a API =====================
+// ===================== Helper: resolve/cache the API pointer =====================
+//
+// Helper typedef for the provider's RequestPluginAPI function.
 using ERF_RequestPluginAPI_Fn = void* (*)(std::uint32_t);
 
+// Name of the provider DLL exporting RequestPluginAPI.
+// Can be overridden at compile time if needed.
 #ifndef ERF_PROVIDER_DLL_NAME
     #define ERF_PROVIDER_DLL_NAME "ElementalReactionsFramework.dll"
 #endif
 
+// Convenience helper to fetch and cache the API pointer.
+// Returns nullptr if the provider DLL or the requested version
+// could not be found or does not match ERF_API_VERSION.
 [[nodiscard]] inline ERF_API_V1* ERF_GetAPI(std::uint32_t v = ERF_API_VERSION) noexcept {
     static HMODULE s_mod = []() noexcept { return ::GetModuleHandleA(ERF_PROVIDER_DLL_NAME); }();
     if (!s_mod) return nullptr;
@@ -127,9 +187,13 @@ using ERF_RequestPluginAPI_Fn = void* (*)(std::uint32_t);
     return (p->version == v) ? p : nullptr;
 }
 
-// (Opcional) messaging legado
+// ===================== messaging helper =====================
+//
+// For consumers that prefer the classic SKSE messaging pattern, this
+// message ID and struct can be used instead of ERF_GetAPI.
 enum : std::uint32_t { ERF_MSG_GET_API = 'ERFA' };
+
 struct ERF_API_Request {
-    std::uint32_t requestedVersion;
-    void* outInterface;
+    std::uint32_t requestedVersion;  // Version requested by the consumer (e.g. ERF_API_VERSION).
+    void* outInterface;              // Pointer to be filled with ERF_API_V1* on success.
 };

--- a/src/ModAPI.cpp
+++ b/src/ModAPI.cpp
@@ -55,11 +55,7 @@ static ERF_ReactionHandle API_RegisterReaction(const ERF_ReactionDesc_Public& d)
     in.minPctEach = d.minPctEach;
     in.minSumSelected = d.minSumSelected;
     in.cooldownSeconds = d.cooldownSeconds;
-    in.cooldownIsRealTime = d.cooldownIsRealTime;
     in.elementLockoutSeconds = d.elementLockoutSeconds;
-    in.elementLockoutIsRealTime = d.elementLockoutIsRealTime;
-    in.clearAllOnTrigger = d.clearAllOnTrigger;
-
     in.Tint = d.hudTint ? d.hudTint : 0xFFFFFF;
     in.iconName = (d.iconName && d.iconName[0] != '\0') ? d.iconName : "";
 

--- a/src/elemental_reactions/erf_reaction.h
+++ b/src/elemental_reactions/erf_reaction.h
@@ -26,10 +26,6 @@ struct ERF_ReactionDesc {
     float elementLockoutSeconds = 0.0f;
 
     bool ordered = false;
-    bool cooldownIsRealTime = true;
-    bool elementLockoutIsRealTime = true;
-    bool clearAllOnTrigger = true;
-
     std::uint32_t Tint = 0xFFFFFF;
     std::string iconName;
 
@@ -84,4 +80,5 @@ private:
 
     bool checkEachElementPct(ERF_ReactionHandle h, const ERF_ReactionDesc& r, std::span<const std::uint8_t> totals,
                              float invSumAll, int& outSumSel) const;
+    bool checkOrdered(const ERF_ReactionDesc& r, std::span<const std::uint8_t> totals) const;
 };

--- a/src/hud/InjectHUD.cpp
+++ b/src/hud/InjectHUD.cpp
@@ -63,13 +63,9 @@ namespace {
 
             ActiveReactionHUD hud{};
             hud.reaction = pr.reaction;
-            hud.realTime = pr.realTime;
             hud.durationS = pr.secs;
 
-            if (pr.realTime)
-                hud.endRtS = nowRt + pr.secs;
-            else
-                hud.endH = nowH + (pr.secs / 3600.0f);
+            hud.endRtS = nowRt + pr.secs;
 
             if (const auto* rd = RR.get(pr.reaction)) {
                 hud.tint = rd->Tint;
@@ -636,7 +632,7 @@ void InjectHUD::UpdateFor(RE::Actor* actor, double nowRt, float nowH) {
              singlesBefore, singlesAfter);
 }
 
-void InjectHUD::BeginReaction(RE::Actor* a, ERF_ReactionHandle handle, float seconds, bool realTime) {
+void InjectHUD::BeginReaction(RE::Actor* a, ERF_ReactionHandle handle, float seconds) {
     if (!a || seconds <= 0.f) return;
 
     auto& st = InjectHUD::Globals();
@@ -647,7 +643,6 @@ void InjectHUD::BeginReaction(RE::Actor* a, ERF_ReactionHandle handle, float sec
     pr.handle = a->CreateRefHandle();
     pr.reaction = handle;
     pr.secs = seconds;
-    pr.realTime = realTime;
 
     std::scoped_lock lk(st.comboMx);
     st.comboQueue.push_back(std::move(pr));

--- a/src/hud/InjectHUD.h
+++ b/src/hud/InjectHUD.h
@@ -19,7 +19,6 @@ namespace InjectHUD {
         RE::ActorHandle handle{};
         ERF_ReactionHandle reaction{};
         float secs{0.f};
-        bool realTime{true};
     };
 
     struct ActiveReactionHUD {
@@ -155,7 +154,7 @@ namespace InjectHUD {
 
     void AddFor(RE::Actor* actor);
     void UpdateFor(RE::Actor* actor, double nowRtS, float nowH);
-    void BeginReaction(RE::Actor* a, ERF_ReactionHandle handle, float seconds, bool realTime);
+    void BeginReaction(RE::Actor* a, ERF_ReactionHandle handle, float seconds);
 
     bool HideFor(RE::FormID id);
     bool RemoveFor(RE::FormID id);

--- a/src/teste.cpp
+++ b/src/teste.cpp
@@ -159,10 +159,7 @@ static void RegisterEverything_Core() {
         rF.minPctEach = 0.85f;
         rF.minSumSelected = 0.0f;
         rF.cooldownSeconds = 0.5f;
-        rF.cooldownIsRealTime = true;
         rF.elementLockoutSeconds = 10.0f;
-        rF.elementLockoutIsRealTime = true;
-        rF.clearAllOnTrigger = true;
         rF.hudTint = 0xF04A3A;
         rF.cb = &OnReactionFire;
         rF.user = nullptr;
@@ -178,10 +175,7 @@ static void RegisterEverything_Core() {
         rFs.minPctEach = 0.9f;
         rFs.minSumSelected = 0.0f;
         rFs.cooldownSeconds = 0.5f;
-        rFs.cooldownIsRealTime = true;
         rFs.elementLockoutSeconds = 10.0f;
-        rFs.elementLockoutIsRealTime = true;
-        rFs.clearAllOnTrigger = true;
         rFs.hudTint = 0xF04A3A;
         rFs.cb = &OnReactionFireS;
         rFs.user = nullptr;
@@ -197,10 +191,7 @@ static void RegisterEverything_Core() {
         rFt.minPctEach = 0.80f;
         rFt.minSumSelected = 0.0f;
         rFt.cooldownSeconds = 0.5f;
-        rFt.cooldownIsRealTime = true;
         rFt.elementLockoutSeconds = 10.0f;
-        rFt.elementLockoutIsRealTime = true;
-        rFt.clearAllOnTrigger = true;
         rFt.hudTint = 0xF04A3A;
         rFt.cb = &OnReactionFireT;
         rFt.user = nullptr;
@@ -217,10 +208,7 @@ static void RegisterEverything_Core() {
         rFr.minPctEach = 0.85f;
         rFr.minSumSelected = 0.0f;
         rFr.cooldownSeconds = 0.5f;
-        rFr.cooldownIsRealTime = true;
         rFr.elementLockoutSeconds = 10.0f;
-        rFr.elementLockoutIsRealTime = true;
-        rFr.clearAllOnTrigger = true;
         rFr.hudTint = 0x4FB2FF;
         rFr.cb = &OnReactionFrost;
         rFr.user = nullptr;
@@ -237,10 +225,7 @@ static void RegisterEverything_Core() {
         rS.minPctEach = 0.85f;
         rS.minSumSelected = 0.0f;
         rS.cooldownSeconds = 0.5f;
-        rS.cooldownIsRealTime = true;
         rS.elementLockoutSeconds = 10.0f;
-        rS.elementLockoutIsRealTime = true;
-        rS.clearAllOnTrigger = true;
         rS.hudTint = 0xFFD02A;
         rS.cb = &OnReactionShock;
         rS.user = nullptr;


### PR DESCRIPTION
… os campos da API deixando apenas os que são usados junto de uma documentação em ingles

## Summary by Sourcery

Document and simplify the public Elemental Reactions API while tightening reaction behavior semantics and HUD timing to a single real‑time model.

New Features:
- Support ordered reactions where the first configured element must be the dominant contributor in the mixture.

Bug Fixes:
- Ensure ordered reactions correctly skip candidates where a non‑first element has higher gauge contribution than the first element.

Enhancements:
- Clarify and translate the public API header to English, documenting handles, descriptors, callbacks, and helper functions.
- Remove unused reaction configuration fields for real‑time vs game‑time cooldowns, element lockouts, and clear‑all behavior, standardizing reactions to real‑time timings and always clearing gauges on trigger.
- Simplify reaction cooldown and element lockout handling to use only real‑time values and align HUD display timing with this model.

Tests:
- Update test/demo reaction registrations to match the streamlined reaction descriptor fields and timing behavior.